### PR TITLE
Scaffold saftao package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Verificador SAF-T (AO)
 
-Ferramenta em Python para validação e correção de ficheiros **SAF-T (AO)** conforme o esquema XSD oficial e regras de negócio da AGT.
+Ferramenta em Python para validação e correção de ficheiros **SAF-T (AO)**
+conforme o esquema XSD oficial e regras de negócio da AGT.
 
-> ℹ️ **Nota importante**  
-> Toda a documentação e organização inicial deste repositório foi gerada pelo **ChatGPT**.  
-> O **Codex GPT** terá a responsabilidade de assumir a evolução do projeto, podendo reorganizar o código, as pastas e a documentação como entender melhor.
+> ℹ️ **Nota importante**
+> Toda a documentação e organização inicial deste repositório foi gerada pelo
+> **ChatGPT**. O **Codex GPT** terá a responsabilidade de assumir a evolução do
+> projeto, podendo reorganizar o código, as pastas e a documentação como
+> entender melhor.
 
 ## Funcionalidades
 - Validação contra XSD oficial (`schemas/SAFTAO1.01_01.xsd`).
-- Validação de regras de negócio estritas (precisão, arredondamento, totais, TaxTable).
+- Validação de regras de negócio estritas (precisão, arredondamento, totais,
+  TaxTable).
 - Correção automática (scripts `autofix_soft` e `autofix_hard`).
 - Geração de logs de erros em Excel (`logs/*.xlsx`).
 
@@ -18,6 +22,9 @@ pip install -r requirements.txt
 ```
 
 ## Utilização
+
+Enquanto a migração para o novo pacote Python decorre, os scripts originais
+continuam disponíveis na raiz do repositório.
 
 ### Validação
 ```bash
@@ -37,12 +44,13 @@ python3 saft_ao_autofix_hard.py FICHEIRO.xml
 ---
 
 ## Estrutura do projeto
-- `validator_saft_ao.py`: valida ficheiros SAF-T AO.  
-- `saft_ao_autofix_soft.py`: aplica correções leves.  
-- `saft_ao_autofix_hard.py`: aplica correções mais profundas.  
-- `schemas/SAFTAO1.01_01.xsd`: schema oficial.  
-- `logs/`: local dos relatórios gerados.  
-- `docs/`: documentação do projeto.
+- `src/saftao/`: novo pacote modular com stubs para validação, auto-fix e
+  utilitários partilhados.
+- `validator_saft_ao.py`, `saft_ao_autofix_soft.py`, `saft_ao_autofix_hard.py`:
+  scripts legacy a migrar para o pacote.
+- `schemas/`: esquema oficial.
+- `docs/`: documentação funcional e técnica.
+- `tests/`: suite de testes (placeholder).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,15 @@
+# Arquitetura Interna
+
+Esta secção documentará os componentes principais do pacote `saftao`.
+
+## Módulos planeados
+
+- `saftao.cli` – ponto de entrada unificado para comandos de linha de comando.
+- `saftao.validator` – serviços de validação e geração de relatórios.
+- `saftao.autofix` – correções automáticas (soft e hard).
+- `saftao.utils` – funções partilhadas (formatação, parsing e namespaces).
+- `saftao.logging` – infraestruturas de logging e geração de relatórios.
+- `saftao.tax_table` e `saftao.invoices` – objetos de domínio e carregamento.
+- `saftao.schema` – resolução de recursos de esquema.
+
+Cada módulo será coberto por testes dedicados na pasta `tests/`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,7 @@
+# Guia de Contribuição
+
+1. Instale as dependências listadas em `requirements.txt` dentro de um ambiente
+   virtual dedicado.
+2. Execute os testes com `pytest` antes de submeter alterações.
+3. Ao migrar lógica dos scripts antigos, assegure-se de cobrir os novos módulos
+   com testes e documentação adequados.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,13 @@
+# SAFT AO Toolkit Overview
+
+Este documento descreve a visão geral para a reorganização em curso do
+projeto. A nova estrutura tem como objetivo disponibilizar um pacote Python
+instalável, com interfaces claras para validação, correção automática e
+utilitários partilhados.
+
+## Estrutura proposta
+
+- `src/saftao/` – código Python modularizado
+- `docs/` – documentação funcional e técnica
+- `schemas/` – recursos XML e XSD
+- `tests/` – testes automatizados

--- a/src/saftao/__init__.py
+++ b/src/saftao/__init__.py
@@ -1,0 +1,16 @@
+"""Top level package for SAFT AO tools.
+
+This module will expose high-level public APIs once the legacy scripts
+from the project root are refactored into this package.
+"""
+
+__all__ = [
+    "cli",
+    "validator",
+    "autofix",
+    "utils",
+    "logging",
+    "tax_table",
+    "invoices",
+    "schema",
+]

--- a/src/saftao/autofix/__init__.py
+++ b/src/saftao/autofix/__init__.py
@@ -1,0 +1,6 @@
+"""Automatic fix utilities for SAFT AO data."""
+
+from .hard import apply_hard_fixes
+from .soft import apply_soft_fixes
+
+__all__ = ["apply_hard_fixes", "apply_soft_fixes"]

--- a/src/saftao/autofix/hard.py
+++ b/src/saftao/autofix/hard.py
@@ -1,0 +1,26 @@
+"""Hard auto-fix routines for SAFT AO XML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from ..logging import ExcelLogger, ExcelLoggerConfig
+from ..validator import ValidationIssue
+
+
+def apply_hard_fixes(path: Path) -> Iterable[ValidationIssue]:
+    """Apply destructive corrections to the given file.
+
+    Once the refactor is complete, this function will wrap the logic from
+    ``saft_ao_autofix_hard.py`` and yield a list of applied fixes.
+    """
+
+    raise NotImplementedError("Hard auto-fixes still need to be implemented")
+
+
+def log_hard_fixes(issues: Iterable[ValidationIssue], *, destination: Path) -> None:
+    """Persist the hard fixes to a spreadsheet log."""
+
+    logger = ExcelLogger(ExcelLoggerConfig(columns=("code", "message"), filename=str(destination)))
+    logger.write_rows(issues)

--- a/src/saftao/autofix/soft.py
+++ b/src/saftao/autofix/soft.py
@@ -1,0 +1,28 @@
+"""Soft auto-fix routines for SAFT AO XML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from ..logging import ExcelLogger, ExcelLoggerConfig
+from ..validator import ValidationIssue
+
+
+def apply_soft_fixes(path: Path) -> Iterable[ValidationIssue]:
+    """Apply non-destructive corrections to the given file.
+
+    The intent is to migrate the behaviours from ``saft_ao_autofix_soft.py``
+    into this module, exposing a clean function that yields issues which were
+    auto-resolved.  The stub raises :class:`NotImplementedError` until that
+    work happens.
+    """
+
+    raise NotImplementedError("Soft auto-fixes still need to be implemented")
+
+
+def log_soft_fixes(issues: Iterable[ValidationIssue], *, destination: Path) -> None:
+    """Persist the soft fixes to a spreadsheet log."""
+
+    logger = ExcelLogger(ExcelLoggerConfig(columns=("code", "message"), filename=str(destination)))
+    logger.write_rows(issues)

--- a/src/saftao/cli.py
+++ b/src/saftao/cli.py
@@ -1,0 +1,24 @@
+"""Command line entry points for SAFT AO utilities."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the base argument parser shared across commands."""
+
+    parser = argparse.ArgumentParser(description="SAFT AO tooling")
+    parser.add_argument("input", type=Path, help="Path to the SAFT AO file")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Execute the command line interface.
+
+    This function exists as a placeholder for a future unified CLI that will
+    coordinate validation and auto-fix subcommands.
+    """
+
+    raise NotImplementedError("CLI entry point not yet implemented")

--- a/src/saftao/invoices.py
+++ b/src/saftao/invoices.py
@@ -1,0 +1,25 @@
+"""Invoice related helpers for SAFT AO."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Iterable
+
+
+@dataclass
+class Invoice:
+    """Lightweight invoice representation used by validators and fixers."""
+
+    number: str
+    customer_tax_id: str
+    issue_date: date
+    gross_total: Decimal
+    net_total: Decimal
+
+
+def load_invoices() -> Iterable[Invoice]:
+    """Load invoices from the underlying SAFT AO document."""
+
+    raise NotImplementedError("Invoice loading not yet implemented")

--- a/src/saftao/logging.py
+++ b/src/saftao/logging.py
@@ -1,0 +1,47 @@
+"""Shared logging helpers for SAFT AO utilities.
+
+The goal of this module is to consolidate the different ``ExcelLogger``
+implementations that exist today in the root-level scripts.  The future
+implementation should expose reusable helpers for generating spreadsheet
+summaries as well as plain-text logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+
+class RowLike(Protocol):
+    """Protocol describing a row serialisable to tabular outputs."""
+
+    def as_cells(self) -> Iterable[str]:
+        """Return the ordered cell values for the row."""
+
+
+@dataclass
+class ExcelLoggerConfig:
+    """Configuration placeholder for the shared Excel logging utility."""
+
+    columns: Iterable[str]
+    filename: str = "saft-ao-report.xlsx"
+
+
+class ExcelLogger:
+    """Stubbed logger that will replace the ad-hoc Excel writers.
+
+    The real implementation should accept rows conforming to :class:`RowLike`
+    and serialise them to the configured output format.
+    """
+
+    def __init__(self, config: ExcelLoggerConfig) -> None:
+        self.config = config
+
+    def write_rows(self, rows: Iterable[RowLike]) -> None:
+        """Persist the provided rows to the configured destination.
+
+        The method is currently a stub and will be implemented once the
+        refactor migrates the legacy scripts into this package.
+        """
+
+        raise NotImplementedError("Excel logging still needs to be implemented")

--- a/src/saftao/schema.py
+++ b/src/saftao/schema.py
@@ -1,0 +1,11 @@
+"""Schema helpers for SAFT AO documents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_schema(name: str) -> Path:
+    """Return the path to the requested schema resource."""
+
+    raise NotImplementedError("Schema resolver not yet implemented")

--- a/src/saftao/tax_table.py
+++ b/src/saftao/tax_table.py
@@ -1,0 +1,26 @@
+"""Tax table data structures and helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable
+
+
+@dataclass
+class TaxEntry:
+    """Representation of a tax table entry."""
+
+    code: str
+    description: str
+    rate: Decimal
+
+
+def load_tax_table() -> Iterable[TaxEntry]:
+    """Load tax entries from a SAFT AO source.
+
+    The concrete implementation will parse XML nodes and reuse utilities from
+    :mod:`saftao.utils` once the refactor takes place.
+    """
+
+    raise NotImplementedError("Tax table loader not yet implemented")

--- a/src/saftao/utils.py
+++ b/src/saftao/utils.py
@@ -1,0 +1,28 @@
+"""Utility helpers shared across SAFT AO modules."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from xml.etree.ElementTree import Element
+
+NS_DEFAULT = "urn:saftao:PT"
+
+
+def detect_namespace(root: Element) -> str:
+    """Return the XML namespace detected for the document root.
+
+    The final implementation should replicate the behaviour of the helper
+    functions present in the legacy scripts.
+    """
+
+    raise NotImplementedError("Namespace detection has not been implemented")
+
+
+def parse_decimal(value: str) -> Decimal:
+    """Convert the provided value to :class:`~decimal.Decimal`.
+
+    This stub exists to highlight the shared need for robust decimal parsing
+    across validator and autofix modules.
+    """
+
+    raise NotImplementedError("Decimal parsing helper still needs to be implemented")

--- a/src/saftao/validator.py
+++ b/src/saftao/validator.py
@@ -1,0 +1,47 @@
+"""Validator entry point for SAFT AO files.
+
+This module will eventually house the refactored logic currently present in
+``validator_saft_ao.py``.  For now, it provides stub classes and functions
+that define the intended public surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .logging import ExcelLogger, ExcelLoggerConfig
+
+
+class ValidationIssue:
+    """Placeholder representation of a problem detected during validation."""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        self.message = message
+        self.code = code or "GENERIC"
+
+    def as_cells(self) -> list[str]:
+        """Serialise the issue for tabular export."""
+
+        return [self.code, self.message]
+
+
+def validate_file(path: Path) -> Iterable[ValidationIssue]:
+    """Validate the provided file.
+
+    The implementation is pending the migration of the existing validator
+    script into the package structure.
+    """
+
+    raise NotImplementedError("Validator logic not yet ported to the package")
+
+
+def export_report(issues: Iterable[ValidationIssue], *, destination: Path) -> None:
+    """Export validation issues to an Excel report.
+
+    This helper demonstrates how the shared logger will be used once the
+    underlying logic is refactored.
+    """
+
+    logger = ExcelLogger(ExcelLoggerConfig(columns=("code", "message"), filename=str(destination)))
+    logger.write_rows(issues)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the SAFT AO refactor."""

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,18 @@
+"""Placeholder tests ensuring the package can be imported."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+
+def test_import_package() -> None:
+    module = importlib.import_module("saftao")
+    assert hasattr(module, "__all__")


### PR DESCRIPTION
## Summary
- add a src/saftao package with stubs for validator, autofix, shared logging, and domain helpers
- document the planned architecture and project layout in the README and docs folder
- add a placeholder pytest suite that imports the new package structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e39ae0f5b88322a8ce575cfa30fa5c