### PR TITLE
Atualizar documentação estratégica e técnica

### DIFF
--- a/docs/FUTURE_PLANS.md
+++ b/docs/FUTURE_PLANS.md
@@ -1,9 +1,30 @@
 # Futuro do projeto
 
-Este projeto será mantido pelo **Codex GPT** a partir de agora.
+Este projeto continuará a ser mantido pelo **Codex GPT** e pela comunidade.
+O foco é evoluir de um conjunto de scripts isolados para uma ferramenta
+modular, bem testada e fácil de operar por utilizadores técnicos e não técnicos.
 
-## Tarefas para Codex
-- Rever a organização de ficheiros e pastas.
-- Analisar o código existente e propor melhorias estruturais.
-- Melhorar a documentação (exemplos, screenshots, fluxos).
-- Criar testes automáticos para garantir robustez.
+## Prioridades de curto prazo
+- **Reorganizar** a estrutura de ficheiros para privilegiar o pacote `src/saftao`
+  como fonte de verdade, mantendo os scripts legados apenas como _wrappers_.
+- **Mapear o estado atual** do código (scripts, CLI e módulos) e propor melhorias
+  na coesão entre eles.
+- **Melhorar a documentação** com fluxos de utilização, exemplos de entrada e
+  saída e tabelas de referência às regras AGT.
+- **Automatizar a validação básica** com _linters_ e testes unitários para as
+  funções críticas de arredondamento e reconciliação de totais.
+
+## Evolução de médio prazo
+- Criar um modo "assistido" na CLI com mensagens mais descritivas e guias sobre
+  como resolver erros frequentes.
+- Consolidar a lógica de correção "soft" e "hard" numa API comum para facilitar
+  integrações com outros sistemas.
+- Publicar _artifacts_ reprodutíveis (p. ex. `pipx`, _container_) para facilitar a
+  adoção em ambientes corporativos.
+
+## Visão de longo prazo
+- Disponibilizar um painel web leve para carregar SAF-T, executar validações e
+  descarregar relatórios.
+- Integrar com serviços de arquivo para guardar _logs_ e históricos de execução.
+- Contribuir de volta para a comunidade SAF-T (AO) através de guias e exemplos
+  oficiais revistos.

--- a/docs/FUTURE_PLANS_chatgpt.md
+++ b/docs/FUTURE_PLANS_chatgpt.md
@@ -1,2 +1,0 @@
-# Futuro
-Codex GPT deve reorganizar e propor melhorias.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1,15 +1,47 @@
 # Implementação
 
-## validator_saft_ao.py
-- Usa `lxml` para parse de XML e validação contra XSD.
-- Implementa funções de arredondamento (q2, q6).
-- Gera log em formato Excel via `openpyxl`.
+Este repositório contém duas gerações de código que convivem enquanto decorre
+uma migração faseada para um pacote Python instalável.
 
-## saft_ao_autofix_soft.py
-- Aplica correções de arredondamento e coerência mínima.
+## Scripts legados na raiz
+- **`validator_saft_ao.py`** — implementa toda a validação estrita, incluindo
+  validação XSD, regras de arredondamento (`q2`, `q6`), reconciliação de totais e
+  geração de _logs_ em Excel através de uma classe `ExcelLogger` própria.
+- **`saft_ao_autofix_soft.py`** — aplica correções não destrutivas: ajusta
+  arredondamentos, normaliza percentagens e assegura a coerência mínima entre
+  totais de documentos.
+- **`saft_ao_autofix_hard.py`** — efetua correções estruturais mais agressivas,
+  reordenando blocos e forçando os totais a respeitarem as regras da AGT.
 
-## saft_ao_autofix_hard.py
-- Reordena blocos, força coerência de totais.
+Estes ficheiros continuam a ser o caminho crítico para utilizadores finais,
+mas servem também como referência funcional para a nova arquitetura.
 
-## Organização de logs
-- Cada execução gera `.xlsx` com erros ou correções aplicadas.
+## Pacote `src/saftao`
+O pacote encapsula a lógica partilhada para validação e correção. Os módulos
+principais são:
+
+| Módulo | Responsabilidade |
+| --- | --- |
+| `cli.py` | Ponto de entrada para uma futura CLI unificada com subcomandos de validação e auto-fix. |
+| `validator.py` | Define a API de validação e classes `ValidationIssue` para exportação de resultados. |
+| `autofix/soft.py` e `autofix/hard.py` | Local destinado à migração das rotinas de correção suave e forte. |
+| `logging.py` | Especifica `ExcelLoggerConfig` e um `ExcelLogger` partilhado para normalizar os relatórios. |
+| `utils.py` | Agrega utilitários de parsing (decimais, _namespaces_) reutilizados entre módulos. |
+| `invoices.py` | Contém a _dataclass_ `Invoice` e abstrações para leitura de documentos. |
+| `tax_table.py` | Modela entradas de tabela de impostos e respetivo carregamento. |
+
+A maioria das funções no pacote ainda está em modo _stub_, em preparação para a
+migração da lógica existente nos scripts legados.
+
+## Registo e relatórios
+- Tanto o `validator_saft_ao.py` como a futura implementação em `src/saftao`
+  produzem relatórios em Excel para facilitar auditorias.
+- Os _logs_ incluem códigos de erro, valores calculados e sugestões de correção,
+  permitindo integração com processos internos de revisão.
+
+## Testes e automação
+- O diretório `tests/` contém casos que exercitam partes fundamentais da
+  validação SAF-T (AO). A expansão desta suíte é essencial para garantir a
+  confiabilidade durante a refatoração.
+- Recomenda-se configurar _CI_ com execução de testes e _linting_ (por exemplo,
+  `pytest`, `ruff`, `mypy`) à medida que os _stubs_ forem implementados.

--- a/docs/IMPLEMENTATION_chatgpt.md
+++ b/docs/IMPLEMENTATION_chatgpt.md
@@ -1,2 +1,0 @@
-# Implementação
-Detalhes técnicos do código.

--- a/docs/OBJECTIVES.md
+++ b/docs/OBJECTIVES.md
@@ -1,5 +1,23 @@
 # Objetivos do projeto
 
-- Garantir que ficheiros SAF-T (AO) respeitam o XSD oficial.
-- Implementar regras estritas de validação.
-- Fornecer scripts de correção automática (soft e hard).
+Este repositório disponibiliza ferramentas para validar e corrigir ficheiros
+SAF-T (AO) segundo as normas da AGT. A visão de produto assenta nos seguintes
+pilares:
+
+## Conformidade
+- Validar ficheiros SAF-T (AO) contra o XSD oficial e um conjunto de regras
+  fiscais adicionais exigidas pela AGT.
+- Garantir cálculos fiáveis de totais (`NetTotal`, `TaxPayable`, `GrossTotal`),
+  arredondamentos (`q2`, `q6`) e percentagens de imposto coerentes.
+
+## Correção assistida
+- Disponibilizar modos de correção "soft" e "hard" para ajustar ficheiros com
+  erros comuns sem intervenção manual extensa.
+- Produzir relatórios em Excel com códigos de erro, sugestões e dados de apoio
+  que acelerem a revisão por equipas de contabilidade ou auditoria.
+
+## Evolução contínua
+- Migrar gradualmente a lógica dos scripts legados para o pacote `src/saftao`,
+  tornando o projeto mais fácil de testar, publicar e integrar.
+- Manter documentação atualizada (arquitetura, _how-to_, notas legais) para
+  reduzir a curva de aprendizagem e incentivar contributos externos.

--- a/docs/OBJECTIVES_chatgpt.md
+++ b/docs/OBJECTIVES_chatgpt.md
@@ -1,2 +1,0 @@
-# Objetivos
-Garantir validação SAF-T AO.


### PR DESCRIPTION
## Summary
- expand future plans with roadmap focusing on reorganização, automação e visão de longo prazo
- detalhar a implementação, destacando scripts legados e o novo pacote `src/saftao`
- clarificar objetivos do projeto em torno de conformidade, correção assistida e evolução contínua
- remover documentos temporários com sufixo `_chatgpt`

## Testing
- not run (documentação apenas)


------
https://chatgpt.com/codex/tasks/task_e_68e3a99e89b4832297ec2bb124cead36