### PR TITLE
Add configuration for pytest, flake8, and black tooling

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist
+per-file-ignores =
+    tests/__init__.py:F401

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ conforme o esquema XSD oficial e regras de negócio da AGT.
 pip install -r requirements.txt
 ```
 
+### Ferramentas de desenvolvimento
+
+Para garantir uma base consistente de testes e linting recomendamos instalar as
+dependências de desenvolvimento e executar as ferramentas de forma regular.
+
+```bash
+pip install -r requirements-dev.txt
+
+# Testes
+pytest
+
+# Linting
+flake8
+
+# Formatação automática
+black .
+```
+
 ## Utilização
 
 Enquanto a migração para o novo pacote Python decorre, os scripts originais

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+include = "\\.pyi?$"
+exclude = """
+/(
+    \\.git
+  | \\.mypy_cache
+  | \\.pytest_cache
+  | build
+  | dist
+)/
+"""
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = [
+  "tests",
+]
+pythonpath = [
+  "src",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=7.4
+flake8>=7.0
+black>=24.0


### PR DESCRIPTION
## Summary
- add development requirements for pytest, flake8, and black and document how to use them
- configure black and pytest defaults in a new pyproject.toml
- add a flake8 configuration tuned for the current repository structure

## Testing
- pytest
- flake8 *(fails due to pre-existing style violations in legacy scripts)*
- black --check . *(fails because legacy files still need to be formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68e3adde06fc8322b5458ec828695681