### PR TITLE
Improve Qt plugin resolution and document venv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,20 @@ conforme o esquema XSD oficial e regras de negócio da AGT.
 - Geração de logs de erros em Excel (`logs/*.xlsx`).
 
 ## Requisitos
+Recomendamos isolar as dependências numa *virtualenv* dedicada. A forma mais
+simples é utilizar o módulo `venv` da própria instalação de Python (>= 3.11):
+
 ```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
+
+> Caso prefira `virtualenvwrapper`, `pyenv` ou ferramentas similares, assegure-se
+> apenas de que o `python` activo corresponde à versão pretendida e que a pasta
+> `PySide6/Qt/plugins` é instalada dentro do ambiente virtual (o comando acima
+> garante isso automaticamente).
 
 ### Ferramentas de desenvolvimento
 

--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -10,11 +10,21 @@ de comandos.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Iterable
 
-from PySide6.QtCore import QObject, Qt, QProcess, QProcessEnvironment, Signal, Slot
+from PySide6.QtCore import (
+    QCoreApplication,
+    QLibraryInfo,
+    QObject,
+    Qt,
+    QProcess,
+    QProcessEnvironment,
+    Signal,
+    Slot,
+)
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
@@ -45,6 +55,95 @@ DEFAULT_XSD = REPO_ROOT / "schemas" / "SAFTAO1.01_01.xsd"
 
 class UserInputError(Exception):
     """Erro de validação provocado por dados introduzidos pelo utilizador."""
+
+
+_PLUGIN_SUFFIXES = {".dll", ".dylib", ".so"}
+
+
+def _ensure_qt_plugin_path() -> None:
+    """Guarantee that Qt can locate platform plugins even inside venvs."""
+
+    discovered = _discover_platform_plugin_dirs()
+    if discovered is None:
+        return
+
+    plugin_root, platform_dir = discovered
+
+    os.environ["QT_PLUGIN_PATH"] = str(plugin_root)
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = str(platform_dir)
+
+    existing_paths = {Path(path) for path in QCoreApplication.libraryPaths()}
+    for directory in (plugin_root, platform_dir):
+        if directory not in existing_paths:
+            QCoreApplication.addLibraryPath(str(directory))
+            existing_paths.add(directory)
+
+
+def _discover_platform_plugin_dirs() -> tuple[Path, Path] | None:
+    """Return ``(plugin_root, platform_dir)`` if any candidate contains plugins."""
+
+    for candidate in _iter_plugin_roots():
+        platform_dir = candidate / "platforms"
+        if _contains_platform_plugins(platform_dir):
+            return candidate, platform_dir
+
+        if candidate.name == "platforms" and _contains_platform_plugins(candidate):
+            return candidate.parent, candidate
+
+    return None
+
+
+def _iter_plugin_roots() -> Iterable[Path]:
+    seen: set[Path] = set()
+
+    for env_name in ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH"):
+        raw_value = os.environ.get(env_name)
+        if not raw_value:
+            continue
+        for chunk in raw_value.split(os.pathsep):
+            if not chunk:
+                continue
+            path = Path(chunk).expanduser().resolve()
+            if path in seen:
+                continue
+            seen.add(path)
+            if env_name == "QT_QPA_PLATFORM_PLUGIN_PATH" and path.name == "platforms":
+                yield path.parent
+            else:
+                yield path
+
+    qt_plugins = Path(QLibraryInfo.path(QLibraryInfo.LibraryPath.PluginsPath)).resolve()
+    if qt_plugins not in seen:
+        seen.add(qt_plugins)
+        yield qt_plugins
+
+    try:
+        import PySide6  # type: ignore
+    except ImportError:  # pragma: no cover - PySide6 is an explicit dependency
+        pass
+    else:
+        pyside_root = Path(PySide6.__file__).resolve().parent
+        for relative in (Path("Qt/plugins"), Path("plugins")):
+            candidate = (pyside_root / relative).resolve()
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            yield candidate
+
+
+def _contains_platform_plugins(directory: Path) -> bool:
+    if not directory.is_dir():
+        return False
+
+    for entry in directory.iterdir():
+        if not entry.is_file():
+            continue
+        suffix = entry.suffix.lower()
+        if suffix in _PLUGIN_SUFFIXES:
+            name = entry.stem.lower()
+            if name.startswith("q") or name.startswith("libq"):
+                return True
+    return False
 
 
 def _create_path_selector(line_edit: QLineEdit, button: QPushButton) -> QWidget:
@@ -489,6 +588,7 @@ class MainWindow(QMainWindow):
 
 
 def main() -> int:
+    _ensure_qt_plugin_path()
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()


### PR DESCRIPTION
## Summary
- ensure the GUI resolves the Qt platform plugins by scanning known installation roots and wiring them into Qt's library paths at startup
- document the recommended virtual environment creation steps so PySide6 installs its plugin directories inside the venv

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3cbba76748322a3ff33d8796e3d7b