### PR TITLE
Use QtGui module for QAction

### DIFF
--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -11,20 +11,24 @@ de comandos.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
+from functools import partial
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
 
 from PySide6.QtCore import (
     QCoreApplication,
     QLibraryInfo,
     QObject,
+    QSettings,
     Qt,
     QProcess,
     QProcessEnvironment,
     Signal,
     Slot,
 )
+from PySide6 import QtGui
 from PySide6.QtGui import QTextCursor
 from PySide6.QtWidgets import (
     QApplication,
@@ -37,19 +41,25 @@ from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QMainWindow,
+    QMenu,
+    QMenuBar,
     QMessageBox,
     QPushButton,
     QPlainTextEdit,
-    QTabWidget,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
 
 
+QAction = QtGui.QAction
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
-VALIDATOR_SCRIPT = REPO_ROOT / "validator_saft_ao.py"
-AUTOFIX_SOFT_SCRIPT = REPO_ROOT / "saft_ao_autofix_soft.py"
-AUTOFIX_HARD_SCRIPT = REPO_ROOT / "saft_ao_autofix_hard.py"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+VALIDATOR_SCRIPT = SCRIPTS_DIR / "validator_saft_ao.py"
+AUTOFIX_SOFT_SCRIPT = SCRIPTS_DIR / "saft_ao_autofix_soft.py"
+AUTOFIX_HARD_SCRIPT = SCRIPTS_DIR / "saft_ao_autofix_hard.py"
 DEFAULT_XSD = REPO_ROOT / "schemas" / "SAFTAO1.01_01.xsd"
 
 
@@ -153,6 +163,84 @@ def _create_path_selector(line_edit: QLineEdit, button: QPushButton) -> QWidget:
     layout.addWidget(line_edit)
     layout.addWidget(button)
     return container
+
+
+class DefaultFolderManager(QObject):
+    """Persiste e divulga as pastas padrão utilizadas pelas operações."""
+
+    folder_changed = Signal(str, Path)
+
+    FOLDER_ORIGIN = "origin"
+    FOLDER_VALIDATION = "validation"
+    FOLDER_FIX_STANDARD = "fix_standard"
+    FOLDER_FIX_HIGH = "fix_high"
+
+    _SETTINGS_PREFIX = "folders"
+    _DEFAULTS: Mapping[str, Path] = {
+        FOLDER_ORIGIN: REPO_ROOT / "work" / "origem",
+        FOLDER_VALIDATION: REPO_ROOT / "work" / "destino" / "verify",
+        FOLDER_FIX_STANDARD: REPO_ROOT / "work" / "destino" / "std",
+        FOLDER_FIX_HIGH: REPO_ROOT / "work" / "destino" / "hard",
+    }
+
+    _LABELS: Mapping[str, str] = {
+        FOLDER_ORIGIN: "Pasta de origem (ficheiros originais)",
+        FOLDER_VALIDATION: "Destino da validação",
+        FOLDER_FIX_STANDARD: "Destino Fix Precisão Standard",
+        FOLDER_FIX_HIGH: "Destino Fix Precisão Alta",
+    }
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._settings = QSettings("bwb", "saftao_gui")
+        self._ensure_structure()
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self._DEFAULTS.keys())
+
+    def label_for(self, key: str) -> str:
+        try:
+            return self._LABELS[key]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Unknown folder key: {key}") from exc
+
+    def get_folder(self, key: str) -> Path:
+        default = self._get_default(key)
+        stored = self._settings.value(self._settings_key(key))
+        if stored:
+            path = Path(str(stored)).expanduser()
+        else:
+            path = default
+        path.mkdir(parents=True, exist_ok=True)
+        return path.resolve()
+
+    def set_folder(self, key: str, value: Path | str) -> Path:
+        new_path = Path(value).expanduser()
+        new_path.mkdir(parents=True, exist_ok=True)
+        new_path = new_path.resolve()
+        current = self.get_folder(key)
+        if current == new_path:
+            return current
+        self._settings.setValue(self._settings_key(key), str(new_path))
+        self.folder_changed.emit(key, new_path)
+        return new_path
+
+    def reset_to_defaults(self) -> None:
+        for key, path in self._DEFAULTS.items():
+            self.set_folder(key, path)
+
+    def _settings_key(self, key: str) -> str:
+        return f"{self._SETTINGS_PREFIX}/{key}"
+
+    def _get_default(self, key: str) -> Path:
+        try:
+            return self._DEFAULTS[key]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"Unknown folder key: {key}") from exc
+
+    def _ensure_structure(self) -> None:
+        for path in self._DEFAULTS.values():
+            path.mkdir(parents=True, exist_ok=True)
 
 
 class CommandRunner(QObject):
@@ -335,10 +423,17 @@ class OperationTab(QWidget):
 class ValidationTab(OperationTab):
     """Executa a validação completa do ficheiro SAF-T."""
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        folders: DefaultFolderManager,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
+        self._folders = folders
         self.xml_edit = QLineEdit()
         self.xsd_edit = QLineEdit(str(DEFAULT_XSD) if DEFAULT_XSD.exists() else "")
+        self.destination_label = QLabel()
+        self.destination_label.setWordWrap(True)
 
         xml_button = QPushButton("Escolher ficheiro…")
         xml_button.clicked.connect(self._select_xml)
@@ -355,14 +450,19 @@ class ValidationTab(OperationTab):
         layout = QVBoxLayout(self)
         layout.addLayout(form)
         layout.addWidget(run_button)
+        layout.addWidget(self.destination_label)
         layout.addWidget(self.status_label)
         layout.addWidget(self.output)
 
+        self._folders.folder_changed.connect(self._on_folder_changed)
+        self._update_destination_label()
+
     def _select_xml(self) -> None:
+        base_dir = self._folders.get_folder(DefaultFolderManager.FOLDER_ORIGIN)
         path, _ = QFileDialog.getOpenFileName(
             self,
             "Selecionar ficheiro SAF-T",
-            str(Path.home()),
+            str(base_dir),
             "Ficheiros SAF-T (*.xml);;Todos os ficheiros (*)",
         )
         if path:
@@ -387,7 +487,8 @@ class ValidationTab(OperationTab):
             xsd_path = self._require_existing_path(xsd_text, "ficheiro XSD")
             arguments.extend(["--xsd", str(xsd_path)])
 
-        return arguments, xml_path.parent
+        destination = self._folders.get_folder(DefaultFolderManager.FOLDER_VALIDATION)
+        return arguments, destination
 
     @staticmethod
     def _require_existing_path(value: str, description: str) -> Path:
@@ -399,14 +500,35 @@ class ValidationTab(OperationTab):
             raise UserInputError(f"O {description} '{path}' não foi encontrado.")
         return path
 
+    def _update_destination_label(self) -> None:
+        destination = self._folders.get_folder(DefaultFolderManager.FOLDER_VALIDATION)
+        self.destination_label.setText(
+            f"Os resultados (ficheiro Excel de log) são gravados em: {destination}"
+        )
+
+    def _on_folder_changed(self, key: str, _path: Path) -> None:
+        if key == DefaultFolderManager.FOLDER_VALIDATION:
+            self._update_destination_label()
+
 
 class AutoFixTab(OperationTab):
     """Base para *tabs* de execução dos scripts de auto-correcção."""
 
-    def __init__(self, script_path: Path, label: str, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        script_path: Path,
+        label: str,
+        folders: DefaultFolderManager,
+        destination_key: str,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self._script_path = script_path
+        self._folders = folders
+        self._destination_key = destination_key
         self.xml_edit = QLineEdit()
+        self.destination_label = QLabel()
+        self.destination_label.setWordWrap(True)
 
         xml_button = QPushButton("Escolher ficheiro…")
         xml_button.clicked.connect(self._select_xml)
@@ -415,7 +537,9 @@ class AutoFixTab(OperationTab):
         self.register_run_button(run_button)
 
         description = QLabel(
-            "O resultado (XML corrigido e log em Excel) é gravado na mesma pasta do ficheiro original."
+            "O ficheiro selecionado é copiado para a pasta de destino configurada "
+            "antes da execução. Os resultados (XML corrigido e log em Excel) "
+            "são gravados nessa pasta."
         )
         description.setWordWrap(True)
 
@@ -426,14 +550,19 @@ class AutoFixTab(OperationTab):
         layout.addLayout(form)
         layout.addWidget(description)
         layout.addWidget(run_button)
+        layout.addWidget(self.destination_label)
         layout.addWidget(self.status_label)
         layout.addWidget(self.output)
 
+        self._folders.folder_changed.connect(self._on_folder_changed)
+        self._update_destination_label()
+
     def _select_xml(self) -> None:
+        base_dir = self._folders.get_folder(DefaultFolderManager.FOLDER_ORIGIN)
         path, _ = QFileDialog.getOpenFileName(
             self,
             "Selecionar ficheiro SAF-T",
-            str(Path.home()),
+            str(base_dir),
             "Ficheiros SAF-T (*.xml);;Todos os ficheiros (*)",
         )
         if path:
@@ -441,7 +570,32 @@ class AutoFixTab(OperationTab):
 
     def build_command(self) -> tuple[list[str], Path | None]:
         xml_path = self._require_existing_path(self.xml_edit.text())
-        return [str(self._script_path), str(xml_path)], xml_path.parent
+        destination_dir = self._folders.get_folder(self._destination_key)
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        destination_file = destination_dir / xml_path.name
+
+        if destination_file.exists():
+            answer = QMessageBox.question(
+                self,
+                "Substituir ficheiro?",
+                (
+                    "Já existe um ficheiro com o mesmo nome na pasta de destino. "
+                    "Pretende substituí-lo?"
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if answer != QMessageBox.StandardButton.Yes:
+                raise UserInputError("Operação cancelada pelo utilizador.")
+
+        try:
+            shutil.copy2(xml_path, destination_file)
+        except OSError as exc:  # pragma: no cover - interação com FS
+            raise UserInputError(
+                f"Não foi possível copiar o ficheiro para '{destination_file}': {exc}"
+            ) from exc
+
+        return [str(self._script_path), str(destination_file)], destination_dir
 
     @staticmethod
     def _require_existing_path(value: str) -> Path:
@@ -452,6 +606,16 @@ class AutoFixTab(OperationTab):
         if not path.exists():
             raise UserInputError(f"O ficheiro '{path}' não foi encontrado.")
         return path
+
+    def _update_destination_label(self) -> None:
+        destination_dir = self._folders.get_folder(self._destination_key)
+        self.destination_label.setText(
+            f"O ficheiro selecionado será copiado para: {destination_dir}"
+        )
+
+    def _on_folder_changed(self, key: str, _path: Path) -> None:
+        if key == self._destination_key or key == DefaultFolderManager.FOLDER_ORIGIN:
+            self._update_destination_label()
 
 
 class RuleUpdateTab(OperationTab):
@@ -572,19 +736,198 @@ class RuleUpdateTab(OperationTab):
         return path
 
 
+class DefaultFoldersWidget(QWidget):
+    """Permite configurar as pastas por defeito utilizadas pelas operações."""
+
+    def __init__(
+        self,
+        folders: DefaultFolderManager,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._folders = folders
+        self._edits: dict[str, QLineEdit] = {}
+
+        description = QLabel(
+            "Configure abaixo as pastas por defeito utilizadas para abrir e "
+            "guardar ficheiros. As pastas são criadas automaticamente caso "
+            "não existam."
+        )
+        description.setWordWrap(True)
+
+        form = QFormLayout()
+        for key in self._folders.keys():
+            edit = QLineEdit(str(self._folders.get_folder(key)))
+            self._edits[key] = edit
+            browse_button = QPushButton("Escolher pasta…")
+            browse_button.clicked.connect(partial(self._select_folder, key))
+            form.addRow(
+                f"{self._folders.label_for(key)}:",
+                _create_path_selector(edit, browse_button),
+            )
+
+        save_button = QPushButton("Guardar alterações")
+        save_button.clicked.connect(self._save_changes)
+        reset_button = QPushButton("Repor valores por defeito")
+        reset_button.clicked.connect(self._reset_defaults)
+
+        button_row = QHBoxLayout()
+        button_row.addWidget(save_button)
+        button_row.addWidget(reset_button)
+        button_row.addStretch(1)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(description)
+        layout.addLayout(form)
+        layout.addLayout(button_row)
+        layout.addStretch(1)
+
+        self._folders.folder_changed.connect(self._on_folder_changed)
+
+    def _select_folder(self, key: str) -> None:
+        current_text = self._edits[key].text().strip()
+        current = Path(current_text).expanduser() if current_text else Path.home()
+        base_dir = current if current.exists() else Path.home()
+        path = QFileDialog.getExistingDirectory(
+            self,
+            "Selecionar pasta",
+            str(base_dir),
+        )
+        if path:
+            self._edits[key].setText(path)
+
+    def _save_changes(self) -> None:
+        new_values: dict[str, Path] = {}
+        for key, edit in self._edits.items():
+            text = edit.text().strip()
+            if not text:
+                QMessageBox.warning(
+                    self,
+                    "Pasta inválida",
+                    "Indique um caminho válido para todas as pastas.",
+                )
+                return
+            new_values[key] = Path(text).expanduser()
+
+        try:
+            for key, path in new_values.items():
+                self._folders.set_folder(key, path)
+        except OSError as exc:  # pragma: no cover - depende do FS
+            QMessageBox.critical(
+                self,
+                "Erro ao guardar",
+                f"Não foi possível atualizar as pastas: {exc}",
+            )
+            return
+
+        QMessageBox.information(self, "Pastas actualizadas", "Alterações guardadas com sucesso.")
+        self._reload_from_manager()
+
+    def _reset_defaults(self) -> None:
+        self._folders.reset_to_defaults()
+        self._reload_from_manager()
+        QMessageBox.information(
+            self,
+            "Valores repostos",
+            "Foram repostas as pastas sugeridas pela aplicação.",
+        )
+
+    def _reload_from_manager(self) -> None:
+        for key, edit in self._edits.items():
+            edit.setText(str(self._folders.get_folder(key)))
+
+    def _on_folder_changed(self, key: str, path: Path) -> None:
+        edit = self._edits.get(key)
+        if edit is not None:
+            edit.setText(str(path))
+
+
 class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Ferramentas SAF-T (AO)")
+        self._folders = DefaultFolderManager(self)
 
-        tabs = QTabWidget()
-        tabs.addTab(ValidationTab(), "Validação")
-        tabs.addTab(AutoFixTab(AUTOFIX_SOFT_SCRIPT, "Executar Auto-Fix Soft"), "Auto-Fix Soft")
-        tabs.addTab(AutoFixTab(AUTOFIX_HARD_SCRIPT, "Executar Auto-Fix Hard"), "Auto-Fix Hard")
-        tabs.addTab(RuleUpdateTab(), "Actualizações de regras")
+        self._stack = QStackedWidget()
+        self.setCentralWidget(self._stack)
 
-        self.setCentralWidget(tabs)
+        self._page_indices: dict[str, int] = {}
+        self._register_page(
+            "validation",
+            ValidationTab(self._folders),
+        )
+        self._register_page(
+            "fix_standard",
+            AutoFixTab(
+                AUTOFIX_SOFT_SCRIPT,
+                "Executar Fix Precisão Standard",
+                self._folders,
+                DefaultFolderManager.FOLDER_FIX_STANDARD,
+            ),
+        )
+        self._register_page(
+            "fix_high",
+            AutoFixTab(
+                AUTOFIX_HARD_SCRIPT,
+                "Executar Fix Precisão Alta",
+                self._folders,
+                DefaultFolderManager.FOLDER_FIX_HIGH,
+            ),
+        )
+        self._register_page("rule_updates", RuleUpdateTab())
+        self._register_page("default_folders", DefaultFoldersWidget(self._folders))
+
+        menubar = self.menuBar()
+        self._build_menus(menubar)
+
         self.resize(1000, 720)
+        self._show_page("validation")
+
+    def _register_page(self, key: str, widget: QWidget) -> None:
+        index = self._stack.addWidget(widget)
+        self._page_indices[key] = index
+
+    def _show_page(self, key: str) -> None:
+        index = self._page_indices.get(key)
+        if index is not None:
+            self._stack.setCurrentIndex(index)
+
+    def _build_menus(self, menubar: QMenuBar) -> None:
+        validation_menu = menubar.addMenu("Validação")
+        self._add_menu_action(
+            validation_menu,
+            "Validação",
+            "validation",
+        )
+
+        corrections_menu = menubar.addMenu("Correções")
+        self._add_menu_action(
+            corrections_menu,
+            "Fix Precisão Standard",
+            "fix_standard",
+        )
+        self._add_menu_action(
+            corrections_menu,
+            "Fix Precisão Alta",
+            "fix_high",
+        )
+
+        parameters_menu = menubar.addMenu("Parâmetros")
+        self._add_menu_action(
+            parameters_menu,
+            "Actualizações de Regras",
+            "rule_updates",
+        )
+        self._add_menu_action(
+            parameters_menu,
+            "Pastas por Defeito",
+            "default_folders",
+        )
+
+    def _add_menu_action(self, menu: QMenu, text: str, key: str) -> QAction:
+        action = menu.addAction(text)
+        action.triggered.connect(lambda _checked=False, target=key: self._show_page(target))
+        return action
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- import the QtGui module so QAction is resolved without touching QtWidgets
- keep QTextCursor import while aliasing QtGui.QAction for action creation

## Testing
- python -m compileall src/saftao/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e3efbf3be48322a3d20aa1ef398227