### PR TITLE
Update GUI background and remove default validation preset

### DIFF
--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -27,6 +27,7 @@ VALIDATOR_SCRIPT = SCRIPTS_DIR / "validator_saft_ao.py"
 AUTOFIX_SOFT_SCRIPT = SCRIPTS_DIR / "saft_ao_autofix_soft.py"
 AUTOFIX_HARD_SCRIPT = SCRIPTS_DIR / "saft_ao_autofix_hard.py"
 DEFAULT_XSD = REPO_ROOT / "schemas" / "SAFTAO1.01_01.xsd"
+SPLASH_IMAGE = Path(__file__).resolve().parent / "bwb-Splash-saftao.jpg"
 LOG_DIR = REPO_ROOT / "work" / "logs"
 LOG_FILE = LOG_DIR / "saftao_gui.log"
 
@@ -175,7 +176,7 @@ from PySide6.QtCore import (
     Signal,
     Slot,
 )
-from PySide6.QtGui import QAction, QTextCursor
+from PySide6.QtGui import QAction, QTextCursor, QPixmap
 from PySide6.QtWidgets import (
     QApplication,
     QFileDialog,
@@ -537,7 +538,7 @@ class ValidationTab(OperationTab):
         super().__init__(parent)
         self._folders = folders
         self.xml_edit = QLineEdit()
-        self.xsd_edit = QLineEdit(str(DEFAULT_XSD) if DEFAULT_XSD.exists() else "")
+        self.xsd_edit = QLineEdit()
         self.destination_label = QLabel()
         self.destination_label.setWordWrap(True)
 
@@ -982,6 +983,7 @@ class MainWindow(QMainWindow):
         self._folders = DefaultFolderManager(self)
 
         self._stack = QStackedWidget()
+        self._stack.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setCentralWidget(self._stack)
 
         self._page_indices: dict[str, int] = {}
@@ -1018,7 +1020,30 @@ class MainWindow(QMainWindow):
         menubar.setNativeMenuBar(False)
         self._build_menus(menubar)
 
-        self.resize(1000, 720)
+        if SPLASH_IMAGE.exists():
+            pixmap = QPixmap(str(SPLASH_IMAGE))
+            if not pixmap.isNull():
+                self.setFixedSize(pixmap.size())
+                image_url = SPLASH_IMAGE.as_posix()
+                self.setStyleSheet(
+                    "QMainWindow {"
+                    f"background-image: url('{image_url}');"
+                    "background-repeat: no-repeat;"
+                    "background-position: center;"
+                    "}"
+                    " QStackedWidget { background: transparent; }"
+                )
+            else:
+                self.resize(1000, 720)
+                self._logger.warning(
+                    "Não foi possível carregar a imagem de fundo em %s.", SPLASH_IMAGE
+                )
+        else:
+            self.resize(1000, 720)
+            self._logger.warning(
+                "Imagem de fundo não encontrada em %s. A usar dimensão padrão.",
+                SPLASH_IMAGE,
+            )
         self._show_page("validation")
         self._logger.info("Janela principal pronta.")
 


### PR DESCRIPTION
## Summary
- prevent the validation tab from pre-filling the XSD path so no validation is configured by default
- size the main window to the splash image and apply it as the window background
- ensure the stacked widget supports the styled background so the splash remains visible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40771182c8322a74b01b1b42886ac