### PR TITLE
Start GUI with blank splash screen

### DIFF
--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -996,6 +996,8 @@ class MainWindow(QMainWindow):
         blank_page.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         blank_page.setStyleSheet("background: transparent;")
         self._blank_index = self._stack.addWidget(blank_page)
+        self._stack.setCurrentIndex(self._blank_index)
+        self._logger.info("Ecrã inicial apresentado sem página activa.")
 
         self._page_indices: dict[str, int] = {}
         self._register_page(
@@ -1055,7 +1057,6 @@ class MainWindow(QMainWindow):
                 "Imagem de fundo não encontrada em %s. A usar dimensão padrão.",
                 SPLASH_IMAGE,
             )
-        self._show_page("validation")
         self._logger.info("Janela principal pronta.")
 
     def _register_page(self, key: str, widget: QWidget) -> None:


### PR DESCRIPTION
## Summary
- set the main window to the blank splash screen when the application loads so no tab is shown by default
- add logging to record when the blank screen is presented on startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40e5f50f083228414a0b3b902946c