### PR TITLE
Fix macOS build workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,4 +1,5 @@
 name: Build macOS .app
+
 on:
   workflow_dispatch:
 
@@ -13,14 +14,14 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install deps
+      - name: Install dependencies
         run: pip install -r requirements.txt pyinstaller
 
       - name: Build .app
-        run: pyinstaller --onefile --windowed --name "Verificador SAFT-AO" validator_saft_ao.py
+        run: pyinstaller --onefile --windowed --name "Verificador SAFT-AO" scripts/validator_saft_ao.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: Verificador_SAFT_AO.app
-          path: dist/Verificador\ SAFT-AO.app
+          path: 'dist/Verificador SAFT-AO.app'


### PR DESCRIPTION
## Summary
- update the macOS build workflow to package the validator from the scripts directory
- ensure the packaged .app artifact path is quoted for upload

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e419eb151c83229dfb6efbc55a1681