### PR TITLE
Switch macOS build to py2app

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,4 +1,5 @@
 name: Build macOS .app
+
 on:
   workflow_dispatch:
 
@@ -13,14 +14,19 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install deps
-        run: pip install -r requirements.txt pyinstaller
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install py2app
 
       - name: Build .app
-        run: pyinstaller --onefile --windowed --name "Verificador SAFT-AO" validator_saft_ao.py
+        env:
+          PYTHONPATH: src
+        run: python setup.py py2app
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: Verificador_SAFT_AO.app
-          path: dist/Verificador\ SAFT-AO.app
+          path: 'dist/Verificador SAFT-AO.app'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from setuptools import setup
+
+APP = ["scripts/validator_saft_ao.py"]
+NAME = "Verificador SAFT-AO"
+IDENTIFIER = "ao.bwb.verificador-saft"
+
+SCHEMA_DIR = Path("schemas")
+RESOURCES = [str(SCHEMA_DIR)] if SCHEMA_DIR.exists() else []
+
+OPTIONS = {
+    "argv_emulation": True,
+    "packages": ["saftao"],
+    "resources": RESOURCES,
+    "plist": {
+        "CFBundleName": NAME,
+        "CFBundleDisplayName": NAME,
+        "CFBundleIdentifier": IDENTIFIER,
+    },
+}
+
+setup(
+    name=NAME,
+    app=APP,
+    options={"py2app": OPTIONS},
+    setup_requires=["py2app"],
+)


### PR DESCRIPTION
## Summary
- switch the macOS build workflow to use py2app with the validator entry point
- ensure the packaged .app bundles the schema resources via a dedicated setup.py script
- ensure the packaged .app artifact path is quoted for upload

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e419eb151c83229dfb6efbc55a1681