### PR TITLE
Fix missing title bar by restoring default window decorations

### DIFF
--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -1090,31 +1090,14 @@ class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Ferramentas SAF-T (AO)")
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
-        self.setAutoFillBackground(False)
-        self.setWindowFlags(
-            self.windowFlags() | Qt.WindowType.FramelessWindowHint
-        )
         self._logger = LOGGER.getChild("MainWindow")
         self._logger.info("Inicialização da janela principal.")
         self._folders = DefaultFolderManager(self)
 
         self._stack = QStackedWidget()
-        self._stack.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        self._stack.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
-        self._stack.setAutoFillBackground(False)
         self.setCentralWidget(self._stack)
 
-        stack_style = "QStackedWidget { background-color: transparent; }"
-        self.setStyleSheet(
-            "QMainWindow { background-color: transparent; } " + stack_style
-        )
-
         blank_page = QWidget()
-        blank_page.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        blank_page.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
-        blank_page.setAutoFillBackground(False)
         self._blank_index = self._stack.addWidget(blank_page)
         self._stack.setCurrentIndex(self._blank_index)
         self._logger.info("Ecrã inicial apresentado sem página activa.")
@@ -1154,13 +1137,10 @@ class MainWindow(QMainWindow):
         self._build_menus(menubar)
 
         self.resize(1000, 720)
-        self._logger.info("Janela principal inicializada com fundo transparente.")
+        self._logger.info("Janela principal inicializada com decorações padrão.")
         self._logger.info("Janela principal pronta.")
 
     def _register_page(self, key: str, widget: QWidget) -> None:
-        widget.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        widget.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
-        widget.setAutoFillBackground(False)
         index = self._stack.addWidget(widget)
         self._page_indices[key] = index
         self._logger.debug("Página '%s' registada no índice %s", key, index)


### PR DESCRIPTION
## Summary
- restore the main window to use the default Qt decorations so the title bar is visible again
- adjust the initialization log message to reflect the standard window decorations

## Testing
- not run (GUI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e427fb98e48322b29d79d4cd1fbbd9