### PR TITLE
Restore translucent client area without removing window decorations

### DIFF
--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -1090,29 +1090,23 @@ class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Ferramentas SAF-T (AO)")
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
-        self.setAutoFillBackground(False)
-        self.setWindowFlags(
-            self.windowFlags() | Qt.WindowType.FramelessWindowHint
-        )
         self._logger = LOGGER.getChild("MainWindow")
         self._logger.info("Inicialização da janela principal.")
         self._folders = DefaultFolderManager(self)
 
         self._stack = QStackedWidget()
-        self._stack.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._stack.setAttribute(
+            Qt.WidgetAttribute.WA_TranslucentBackground, True
+        )
         self._stack.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
         self._stack.setAutoFillBackground(False)
+        self._stack.setStyleSheet("background-color: transparent;")
         self.setCentralWidget(self._stack)
 
-        stack_style = "QStackedWidget { background-color: transparent; }"
-        self.setStyleSheet(
-            "QMainWindow { background-color: transparent; } " + stack_style
-        )
-
         blank_page = QWidget()
-        blank_page.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        blank_page.setAttribute(
+            Qt.WidgetAttribute.WA_TranslucentBackground, True
+        )
         blank_page.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
         blank_page.setAutoFillBackground(False)
         self._blank_index = self._stack.addWidget(blank_page)
@@ -1154,7 +1148,9 @@ class MainWindow(QMainWindow):
         self._build_menus(menubar)
 
         self.resize(1000, 720)
-        self._logger.info("Janela principal inicializada com fundo transparente.")
+        self._logger.info(
+            "Janela principal inicializada com decorações padrão e conteúdo transparente."
+        )
         self._logger.info("Janela principal pronta.")
 
     def _register_page(self, key: str, widget: QWidget) -> None:


### PR DESCRIPTION
## Summary
- make the stacked central widget and blank page translucent so the client area remains transparent
- apply the same transparency attributes to each page while keeping the standard window chrome
- update the initialization log message to reflect the transparent content with default decorations

## Testing
- not run (GUI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e427fb98e48322b29d79d4cd1fbbd9