### PR TITLE
Document VD invoice validation issue and add auto-fix stub

### DIFF
--- a/docs/erros_validacao_vd_customer.md
+++ b/docs/erros_validacao_vd_customer.md
@@ -1,0 +1,20 @@
+# Erros de validação detectados
+
+Este documento regista os problemas encontrados na validação do ficheiro `AO5002185695_1_20250801_000000_20250831_235959_20251006233531_v.02_invalido.xml` e as acções propostas para os resolver.
+
+## 1. Código de fatura `InvoiceType="VD"`
+
+* **Erro reportado:** o XSD rejeita o código `VD` porque não pertence à enumeração válida (`FT`, `FR`, `GF`, `FG`, `AC`, `AR`, `ND`, `NC`, `AF`, `TV`, `RP`, `RE`, `CS`, `LD`, `RA`).
+* **Impacto:** impede o envio do ficheiro para a AGT.
+* **Resolução proposta:** normalizar `VD` para `FR`, por ser o único tipo que representa venda com recebimento imediato. Esta substituição será automatizada numa rotina de *soft auto-fix*.
+
+## 2. Cliente `CustomerID = 100250`
+
+* **Erro reportado:** a validação acusa a ausência do cliente `100250` na secção `MasterFiles/Customer`.
+* **Observação:** o registo existe na base de dados da aplicação; será necessário confirmar porque não foi exportado para o SAF-T.
+* **Resolução proposta:** investigar a rotina de exportação para garantir que o cliente é sempre incluído, ou ajustar a lógica de construção do ficheiro para replicar os dados presentes na aplicação.
+
+## Próximos passos
+
+* Implementar o *auto-fix* que converte `InvoiceType="VD"` em `FR`.
+* Rever a extracção de clientes para garantir que o identificador `100250` (e quaisquer outros utilizados) está presente no bloco `MasterFiles`.

--- a/src/saftao/autofix/__init__.py
+++ b/src/saftao/autofix/__init__.py
@@ -1,6 +1,6 @@
 """Automatic fix utilities for SAFT AO data."""
 
 from .hard import apply_hard_fixes
-from .soft import apply_soft_fixes
+from .soft import apply_soft_fixes, normalize_invoice_type_vd
 
-__all__ = ["apply_hard_fixes", "apply_soft_fixes"]
+__all__ = ["apply_hard_fixes", "apply_soft_fixes", "normalize_invoice_type_vd"]

--- a/src/saftao/autofix/soft.py
+++ b/src/saftao/autofix/soft.py
@@ -21,6 +21,20 @@ def apply_soft_fixes(path: Path) -> Iterable[ValidationIssue]:
     raise NotImplementedError("Soft auto-fixes still need to be implemented")
 
 
+def normalize_invoice_type_vd(path: Path) -> Iterable[ValidationIssue]:
+    """Placeholder for converting ``InvoiceType="VD"`` into ``"FR"`` entries.
+
+    A futura implementação deverá percorrer o ficheiro XML, substituir o valor
+    inválido e devolver a lista de :class:`ValidationIssue` que descrevem as
+    correcções aplicadas.  Enquanto a migração não estiver concluída, o stub
+    informa explicitamente que a funcionalidade está pendente.
+    """
+
+    raise NotImplementedError(
+        "Normalização de InvoiceType 'VD' ainda não foi implementada"
+    )
+
+
 def log_soft_fixes(issues: Iterable[ValidationIssue], *, destination: Path) -> None:
     """Persist the soft fixes to a spreadsheet log."""
 


### PR DESCRIPTION
## Summary
- document the validation errors affecting InvoiceType "VD" and missing customer exports
- expose a soft auto-fix stub dedicated to normalising InvoiceType "VD" values
- re-export the new stub through the autofix package interface for future use

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68e445e9703c832286ad4482925ffd94