### PR TITLE
Ensure auto-added customers respect MasterFiles order

### DIFF
--- a/docs/erros_validacao_vd_customer.md
+++ b/docs/erros_validacao_vd_customer.md
@@ -22,14 +22,12 @@ Este documento regista os problemas encontrados na validação do ficheiro `AO50
 
 ## Próximos passos
 
-* Implementar o *auto-fix* que converte `InvoiceType="VD"` em `FR`.
-* Implementar a verificação preventiva que garante a presença de todos os clientes referenciados no bloco `MasterFiles`.
+* ✅ *Auto-fix* actualizado para converter `InvoiceType="VD"` em `FR` automaticamente durante o processo de correcções.
+* ✅ Rotina interactiva que garante a presença de todos os clientes referenciados no bloco `MasterFiles`, recorrendo ao ficheiro Excel indicado pelo utilizador.
 
 ## 3. Actualizações planeadas
 
 | Item | Objectivo | Como será feito |
 | ---- | --------- | --------------- |
-| Normalização `VD` | Substituir automaticamente `InvoiceType="VD"` por `FR` durante a geração do ficheiro. | Através da função `normalize_invoice_type_vd`, que vai editar o nó `<InvoiceType>` e registar a alteração nos *logs* de auto-fix. |
-| Verificação de clientes | Garantir que todos os `CustomerID` referenciados existem em `MasterFiles/Customer`. | Com a função `ensure_invoice_customers_exported`, que vai comparar os identificadores usados nas facturas com os clientes exportados e emitir uma correcção automática caso falte algum registo. |
-
-> **Nota:** ambas as funções encontram-se actualmente em *stub* e serão completadas na próxima iteração de desenvolvimento.
+| Normalização `VD` | Substituir automaticamente `InvoiceType="VD"` por `FR` durante a geração do ficheiro. | Implementado pela função `normalize_invoice_type_vd`, integrada no script de auto-fix e registada no log Excel. |
+| Verificação de clientes | Garantir que todos os `CustomerID` referenciados existem em `MasterFiles/Customer`. | Implementado pela função `ensure_invoice_customers_exported`, que compara os identificadores usados nas facturas com os clientes exportados, procura automaticamente o ficheiro fixo `work/origem/addons/Listagem_de_Clientes.xlsx` e cria os registos em falta. |

--- a/scripts/saft_ao_autofix_soft.py
+++ b/scripts/saft_ao_autofix_soft.py
@@ -39,11 +39,22 @@ from datetime import datetime
 from lxml import etree
 from typing import Optional, Dict, Any, List
 
-# Precisão alta
-getcontext().prec = 28
-
 SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+for path in (PROJECT_ROOT, SRC_DIR):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+from saftao.autofix.soft import (
+    ensure_invoice_customers_exported_tree,
+    normalize_invoice_type_vd_tree,
+)
+
+# Precisão alta
+getcontext().prec = 28
 
 NS_DEFAULT = "urn:OECD:StandardAuditFile-Tax:AO_1.01_01"
 AMT2 = Decimal("0.01")
@@ -385,6 +396,18 @@ def fix_xml(
     ns = {"n": nsuri}
     root = tree.getroot()
 
+    vd_issues = normalize_invoice_type_vd_tree(tree)
+    for issue in vd_issues:
+        logger.log(
+            issue.code,
+            "InvoiceType normalizado para FR",
+            invoice=issue.details.get("invoice", ""),
+            field="InvoiceType",
+            old_value="VD",
+            new_value="FR",
+            note=issue.message,
+        )
+
     # 0) Limpeza: remover TaxCountryRegion (não existe em AO)
     purge_tax_country_region(root, nsuri, logger)
 
@@ -582,6 +605,32 @@ def fix_xml(
         set_total("GrossTotal", gross2)
         ensure_document_totals_order(doc_totals)
 
+    try:
+        customer_issues = ensure_invoice_customers_exported_tree(tree)
+    except Exception as exc:
+        logger.log(
+            "AUTOADD_CUSTOMER_FAIL",
+            "Falha ao adicionar clientes em falta",
+            note=str(exc),
+        )
+        raise
+
+    for issue in customer_issues:
+        extra: Dict[str, Any] | None = None
+        if issue.details:
+            extra = {
+                key: value
+                for key, value in issue.details.items()
+                if key in {"customer_id", "source"}
+            }
+        logger.log(
+            issue.code,
+            "Cliente adicionado ao MasterFiles",
+            field="Customer",
+            note=issue.message,
+            extra=extra,
+        )
+
     return tree
 
 
@@ -678,7 +727,13 @@ def main() -> None:
         logger.flush()
         sys.exit(2)
 
-    tree = fix_xml(tree, in_path, logger)
+    try:
+        tree = fix_xml(tree, in_path, logger)
+    except Exception as exc:
+        print(f"[ERRO] Falha ao aplicar correcções: {exc}")
+        logger.log("FIX_ERROR", "Falha ao aplicar correcções", note=str(exc))
+        logger.flush()
+        sys.exit(2)
 
     xsd_path = default_xsd_path()
     out_ok, out_bad, version_suffix = next_version_paths(in_path, output_dir)

--- a/src/saftao/autofix/soft.py
+++ b/src/saftao/autofix/soft.py
@@ -2,11 +2,34 @@
 
 from __future__ import annotations
 
+import os
+import unicodedata
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from lxml import etree
+
 from ..logging import ExcelLogger, ExcelLoggerConfig
 from ..validator import ValidationIssue
+
+_EXCEL_ENV_VARIABLE = "BWB_SAFTAO_CUSTOMER_FILE"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_ADDONS_DIR = _REPO_ROOT / "work" / "origem" / "addons"
+_DEFAULT_CUSTOMER_FILENAME = "Listagem_de_Clientes.xlsx"
+
+
+@dataclass
+class _CustomerRecord:
+    """Representa os dados mínimos necessários para criar um cliente."""
+
+    customer_id: str
+    company_name: str
+    tax_id: str
+    city: str
+    country: str
+    telephone: str
+    source_path: Path
 
 
 def apply_soft_fixes(path: Path) -> Iterable[ValidationIssue]:
@@ -22,19 +45,116 @@ def apply_soft_fixes(path: Path) -> Iterable[ValidationIssue]:
 
 
 def normalize_invoice_type_vd(path: Path) -> Iterable[ValidationIssue]:
-    """Placeholder for converting ``InvoiceType="VD"`` into ``"FR"`` entries."""
+    """Replace ``InvoiceType="VD"`` entries with ``"FR"`` in-place."""
 
-    raise NotImplementedError(
-        "Normalização de InvoiceType 'VD' ainda não foi implementada"
-    )
+    tree = etree.parse(str(path))
+    issues = normalize_invoice_type_vd_tree(tree)
+    if issues:
+        tree.write(
+            str(path),
+            encoding="utf-8",
+            xml_declaration=True,
+            pretty_print=True,
+        )
+    return issues
+
+
+def normalize_invoice_type_vd_tree(
+    tree: etree._ElementTree,
+) -> list[ValidationIssue]:
+    """Apply the ``VD`` → ``FR`` normalisation to an in-memory XML tree."""
+
+    root = tree.getroot()
+    ns_uri = _detect_namespace(root)
+    namespaces = {"n": ns_uri} if ns_uri else None
+
+    if namespaces:
+        xpath = ".//n:SourceDocuments/n:SalesInvoices/n:Invoice"
+        invoices = root.xpath(xpath, namespaces=namespaces)
+    else:
+        invoices = root.findall(".//SourceDocuments/SalesInvoices/Invoice")
+
+    issues: list[ValidationIssue] = []
+    for invoice in invoices:
+        invoice_type = _find_child(invoice, "InvoiceType", ns_uri)
+        if invoice_type is None:
+            continue
+        value = (invoice_type.text or "").strip()
+        if value.upper() != "VD":
+            continue
+
+        invoice_no = _find_child_text(invoice, "InvoiceNo", ns_uri) or "(sem número)"
+        invoice_type.text = "FR"
+        issues.append(
+            ValidationIssue(
+                f"Invoice '{invoice_no}': InvoiceType 'VD' substituído por 'FR'.",
+                code="FIX_INVOICE_TYPE",
+                details={"invoice": invoice_no},
+            )
+        )
+
+    return issues
 
 
 def ensure_invoice_customers_exported(path: Path) -> Iterable[ValidationIssue]:
-    """Ensure every customer referenced by an invoice is present in MasterFiles."""
+    """Ensure every customer referenced by an invoice is present in MasterFiles.
 
-    raise NotImplementedError(
-        "Verificação de clientes exportados ainda não foi implementada"
-    )
+    Esta rotina detecta clientes utilizados nas facturas que ainda não estejam
+    presentes no bloco ``MasterFiles/Customer`` do ficheiro SAF-T. Caso sejam
+    identificadas ausências, o utilizador é solicitado a indicar o ficheiro
+    Excel com a tabela de clientes (padrão ``work/origem/addons``). Os registos
+    em falta são adicionados automaticamente ao XML.
+    """
+
+    tree = etree.parse(str(path))
+    issues = ensure_invoice_customers_exported_tree(tree)
+    if issues:
+        tree.write(
+            str(path),
+            encoding="utf-8",
+            xml_declaration=True,
+            pretty_print=True,
+        )
+    return issues
+
+
+def ensure_invoice_customers_exported_tree(
+    tree: etree._ElementTree,
+) -> list[ValidationIssue]:
+    """Ensure every invoice customer exists in ``MasterFiles`` for ``tree``."""
+
+    root = tree.getroot()
+    ns_uri = _detect_namespace(root)
+    namespaces = {"n": ns_uri} if ns_uri else None
+
+    invoice_ids = _collect_invoice_customer_ids(root, namespaces)
+    existing_ids = _collect_masterfile_customer_ids(root, namespaces)
+
+    missing_ids = [cid for cid in invoice_ids if cid not in existing_ids]
+    if not missing_ids:
+        return []
+
+    records = _gather_customer_records(missing_ids)
+
+    masterfiles = _ensure_masterfiles_node(root, ns_uri)
+
+    issues: list[ValidationIssue] = []
+    for customer_id in missing_ids:
+        record = records[customer_id]
+        _append_customer(masterfiles, ns_uri, record)
+        issues.append(
+            ValidationIssue(
+                f"Cliente '{customer_id}' adicionado ao MasterFiles com dados de "
+                f"'{record.source_path.name}'.",
+                code="AUTOADD_CUSTOMER",
+                details={
+                    "customer_id": customer_id,
+                    "source": str(record.source_path),
+                },
+            )
+        )
+
+    return issues
 
 
 def log_soft_fixes(issues: Iterable[ValidationIssue], *, destination: Path) -> None:
@@ -44,3 +164,366 @@ def log_soft_fixes(issues: Iterable[ValidationIssue], *, destination: Path) -> N
         ExcelLoggerConfig(columns=("code", "message"), filename=str(destination))
     )
     logger.write_rows(issues)
+
+
+def _detect_namespace(root: etree._Element) -> str:
+    tag = root.tag
+    if tag.startswith("{") and "}" in tag:
+        return tag.split("}", 1)[0][1:]
+    return ""
+
+
+def _collect_invoice_customer_ids(
+    root: etree._Element, namespaces: dict[str, str] | None
+) -> list[str]:
+    if namespaces:
+        xpath = ".//n:SourceDocuments/n:SalesInvoices/n:Invoice//n:CustomerID"
+        nodes = root.xpath(xpath, namespaces=namespaces)
+    else:
+        nodes = root.findall(
+            ".//SourceDocuments/SalesInvoices/Invoice//CustomerID"
+        )
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for node in nodes:
+        text = (node.text or "").strip()
+        if not text or text in seen:
+            continue
+        ordered.append(text)
+        seen.add(text)
+    return ordered
+
+
+def _collect_masterfile_customer_ids(
+    root: etree._Element, namespaces: dict[str, str] | None
+) -> set[str]:
+    if namespaces:
+        xpath = ".//n:MasterFiles/n:Customer/n:CustomerID"
+        nodes = root.xpath(xpath, namespaces=namespaces)
+    else:
+        nodes = root.findall(".//MasterFiles/Customer/CustomerID")
+
+    ids: set[str] = set()
+    for node in nodes:
+        text = (node.text or "").strip()
+        if text:
+            ids.add(text)
+    return ids
+
+
+def _gather_customer_records(missing_ids: list[str]) -> dict[str, _CustomerRecord]:
+    env_path = os.environ.get(_EXCEL_ENV_VARIABLE)
+    if env_path:
+        excel_path = Path(env_path).expanduser()
+        if not excel_path.exists():
+            raise FileNotFoundError(
+                f"O ficheiro Excel definido em {_EXCEL_ENV_VARIABLE} não existe: {excel_path}"
+            )
+        return _map_records_for_missing_ids(excel_path, missing_ids)
+
+    default_excel = _DEFAULT_ADDONS_DIR / _DEFAULT_CUSTOMER_FILENAME
+    if default_excel.exists():
+        return _map_records_for_missing_ids(default_excel, missing_ids)
+
+    return _gather_records_interactively(missing_ids)
+
+
+def _map_records_for_missing_ids(
+    excel_path: Path, missing_ids: list[str]
+) -> dict[str, _CustomerRecord]:
+    records = _load_records_from_excel(excel_path)
+    result: dict[str, _CustomerRecord] = {}
+    missing_from_file: list[str] = []
+    for customer_id in missing_ids:
+        data = records.get(customer_id)
+        if data is None:
+            missing_from_file.append(customer_id)
+            continue
+        result[customer_id] = _CustomerRecord(**data, source_path=excel_path)
+    if missing_from_file:
+        missing_str = ", ".join(missing_from_file)
+        raise ValueError(
+            "Os seguintes clientes em falta não foram encontrados no ficheiro "
+            f"{excel_path}: {missing_str}"
+        )
+    return result
+
+
+def _gather_records_interactively(
+    missing_ids: list[str],
+) -> dict[str, _CustomerRecord]:
+    from PySide6.QtWidgets import QApplication, QMessageBox
+
+    _DEFAULT_ADDONS_DIR.mkdir(parents=True, exist_ok=True)
+
+    app = QApplication.instance()
+    created_app = False
+    if app is None:
+        app = QApplication([])
+        created_app = True
+
+    try:
+        _show_message(
+            QMessageBox.Icon.Warning,
+            "Clientes em falta no MasterFiles",
+            "Foram detectados clientes nas facturas que não existem no MasterFiles.",
+            QMessageBox.StandardButton.Ok,
+            (
+                "Os seguintes identificadores precisam de ser adicionados:\n- "
+                + "\n- ".join(missing_ids)
+                + "\n\nA aplicação irá procurar automaticamente o ficheiro "
+                f"'{_DEFAULT_CUSTOMER_FILENAME}' em {_DEFAULT_ADDONS_DIR}."
+            ),
+        )
+
+        excel_path = _DEFAULT_ADDONS_DIR / _DEFAULT_CUSTOMER_FILENAME
+
+        if not excel_path.exists():
+            _show_message(
+                QMessageBox.Icon.Critical,
+                "Ficheiro de clientes não encontrado",
+                (
+                    "Não foi possível localizar o ficheiro fixo de clientes. "
+                    f"Certifique-se de que '{excel_path.name}' existe em {_DEFAULT_ADDONS_DIR}."
+                ),
+                QMessageBox.StandardButton.Ok,
+            )
+            raise FileNotFoundError(
+                f"Ficheiro de clientes obrigatório não encontrado: {excel_path}"
+            )
+
+        try:
+            collected = _map_records_for_missing_ids(excel_path, missing_ids)
+        except ValueError as exc:
+            _show_message(
+                QMessageBox.Icon.Critical,
+                "Clientes em falta no ficheiro",
+                str(exc),
+                QMessageBox.StandardButton.Ok,
+            )
+            raise
+        except Exception as exc:  # pragma: no cover - interface interativa
+            _show_message(
+                QMessageBox.Icon.Critical,
+                "Erro ao ler ficheiro Excel",
+                str(exc),
+                QMessageBox.StandardButton.Ok,
+            )
+            raise
+
+        return collected
+    finally:
+        if created_app:
+            app.quit()
+
+
+def _show_message(
+    icon: "QMessageBox.Icon",
+    title: str,
+    text: str,
+    buttons: "QMessageBox.StandardButton",
+    informative_text: str | None = None,
+) -> None:
+    from PySide6.QtCore import Qt, QTimer
+    from PySide6.QtWidgets import QMessageBox
+
+    box = QMessageBox()
+    box.setIcon(icon)
+    box.setWindowTitle(title)
+    box.setText(text)
+    if informative_text:
+        box.setInformativeText(informative_text)
+    box.setStandardButtons(buttons)
+    box.setWindowModality(Qt.ApplicationModal)
+    box.setWindowFlag(Qt.WindowStaysOnTopHint, True)
+
+    def _raise_box() -> None:
+        box.raise_()
+        box.activateWindow()
+
+    QTimer.singleShot(0, _raise_box)
+    box.exec()
+
+
+def _load_records_from_excel(path: Path) -> dict[str, dict[str, str]]:
+    from openpyxl import load_workbook
+
+    if not path.exists():
+        raise FileNotFoundError(f"Ficheiro Excel não encontrado: {path}")
+
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    sheet = workbook.active
+
+    rows = list(sheet.iter_rows(values_only=True))
+    workbook.close()
+    if not rows:
+        raise ValueError("O ficheiro Excel não contém dados.")
+
+    header = rows[0]
+    column_map = _build_column_map(header)
+
+    records: dict[str, dict[str, str]] = {}
+    for row in rows[1:]:
+        if row is None:
+            continue
+        customer_id = _normalise_excel_value(
+            _value_at(row, column_map["codigo"])
+        )
+        if not customer_id:
+            continue
+        records[customer_id] = {
+            "customer_id": customer_id,
+            "company_name": _normalise_excel_value(
+                _value_at(row, column_map["nome"])
+            ),
+            "tax_id": _normalise_excel_value(
+                _value_at(row, column_map["contribuinte"])
+            ),
+            "city": _normalise_excel_value(
+                _value_at(row, column_map["localidade"])
+            ),
+            "country": _normalise_excel_value(
+                _value_at(row, column_map["pais"])
+            )
+            or "AO",
+            "telephone": _normalise_excel_value(
+                _value_at(row, column_map["telemovel"])
+            ),
+        }
+
+    if not records:
+        raise ValueError(
+            "Nenhum registo de cliente válido foi encontrado no ficheiro Excel."
+        )
+    return records
+
+
+def _build_column_map(header: tuple[object, ...]) -> dict[str, int]:
+    required = {
+        "codigo": "Código",
+        "nome": "Nome",
+        "contribuinte": "Contribuinte",
+        "localidade": "Localidade",
+        "pais": "País",
+        "telemovel": "Telemovel",
+    }
+
+    mapping: dict[str, int] = {}
+    for index, value in enumerate(header):
+        key = _normalise_header(value)
+        if key in required and key not in mapping:
+            mapping[key] = index
+
+    missing = [orig for key, orig in required.items() if key not in mapping]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(
+            "O ficheiro Excel não contém todas as colunas obrigatórias: "
+            f"{joined}."
+        )
+    return mapping
+
+
+def _normalise_header(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    normalised = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in normalised if not unicodedata.combining(ch))
+
+
+def _normalise_excel_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        if value.is_integer():
+            return str(int(value))
+        return f"{value:g}"
+    return str(value).strip()
+
+
+def _value_at(row: tuple[object, ...], index: int) -> object:
+    if index >= len(row):
+        return None
+    return row[index]
+
+
+def _ensure_masterfiles_node(root: etree._Element, ns_uri: str) -> etree._Element:
+    tag = _ns_tag("MasterFiles", ns_uri)
+    masterfiles = root.find(f".//{tag}")
+    if masterfiles is not None:
+        return masterfiles
+
+    masterfiles = etree.Element(tag)
+
+    source_tag = _ns_tag("SourceDocuments", ns_uri)
+    for index, child in enumerate(root):
+        if child.tag == source_tag:
+            root.insert(index, masterfiles)
+            break
+    else:
+        root.append(masterfiles)
+    return masterfiles
+
+
+def _append_customer(
+    masterfiles: etree._Element, ns_uri: str, record: _CustomerRecord
+) -> None:
+    customer_tag = _ns_tag("Customer", ns_uri)
+
+    insertion_order = {
+        _ns_tag("Supplier", ns_uri),
+        _ns_tag("Product", ns_uri),
+        _ns_tag("TaxTable", ns_uri),
+    }
+
+    insert_at = len(masterfiles)
+    for index, child in enumerate(masterfiles):
+        if child.tag in insertion_order:
+            insert_at = index
+            break
+
+    if insert_at == len(masterfiles):
+        customer = etree.SubElement(masterfiles, customer_tag)
+    else:
+        customer = etree.Element(customer_tag)
+        masterfiles.insert(insert_at, customer)
+
+    def add_element(parent: etree._Element, name: str, text: str) -> etree._Element:
+        element = etree.SubElement(parent, _ns_tag(name, ns_uri))
+        element.text = text
+        return element
+
+    add_element(customer, "CustomerID", record.customer_id)
+    add_element(customer, "AccountID", record.customer_id)
+    add_element(customer, "CustomerTaxID", record.tax_id or "999999990")
+    add_element(customer, "CompanyName", record.company_name or record.customer_id)
+
+    billing = etree.SubElement(customer, _ns_tag("BillingAddress", ns_uri))
+    add_element(billing, "AddressDetail", record.company_name or "Morada não fornecida")
+    add_element(billing, "City", record.city or "Desconhecida")
+    if record.country:
+        add_element(billing, "Country", record.country)
+    else:
+        add_element(billing, "Country", "AO")
+
+    if record.telephone:
+        add_element(customer, "Telephone", record.telephone)
+
+    add_element(customer, "SelfBillingIndicator", "0")
+
+
+def _ns_tag(name: str, ns_uri: str) -> str:
+    return f"{{{ns_uri}}}{name}" if ns_uri else name
+
+
+def _find_child(parent: etree._Element, name: str, ns_uri: str) -> etree._Element | None:
+    return parent.find(_ns_tag(name, ns_uri))
+
+
+def _find_child_text(parent: etree._Element, name: str, ns_uri: str) -> str:
+    child = _find_child(parent, name, ns_uri)
+    if child is None or child.text is None:
+        return ""
+    return child.text.strip()

--- a/src/saftao/validator.py
+++ b/src/saftao/validator.py
@@ -16,9 +16,16 @@ from .logging import ExcelLogger, ExcelLoggerConfig
 class ValidationIssue:
     """Placeholder representation of a problem detected during validation."""
 
-    def __init__(self, message: str, *, code: str | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        details: dict[str, str] | None = None,
+    ) -> None:
         self.message = message
         self.code = code or "GENERIC"
+        self.details = details or {}
 
     def as_cells(self) -> list[str]:
         """Serialise the issue for tabular export."""

--- a/tests/test_customer_excel_import.py
+++ b/tests/test_customer_excel_import.py
@@ -1,0 +1,206 @@
+"""Tests for importing missing customers from Excel into MasterFiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lxml import etree
+from openpyxl import Workbook
+
+from saftao.autofix.soft import (
+    _DEFAULT_CUSTOMER_FILENAME,
+    ensure_invoice_customers_exported,
+)
+
+
+NAMESPACE = "urn:OECD:StandardAuditFile-Tax:AO_1.01_01"
+NS = {"n": NAMESPACE}
+
+
+def _create_sample_xml(path: Path) -> None:
+    content = f"""<?xml version='1.0' encoding='UTF-8'?>
+<AuditFile xmlns=\"{NAMESPACE}\">
+  <Header></Header>
+  <MasterFiles>
+    <Customer>
+      <CustomerID>EXISTING</CustomerID>
+      <AccountID>EXISTING</AccountID>
+      <CustomerTaxID>123456789</CustomerTaxID>
+      <CompanyName>Cliente Existente</CompanyName>
+      <BillingAddress>
+        <AddressDetail>Morada existente</AddressDetail>
+        <City>Luanda</City>
+        <Country>AO</Country>
+      </BillingAddress>
+      <SelfBillingIndicator>0</SelfBillingIndicator>
+    </Customer>
+  </MasterFiles>
+  <SourceDocuments>
+    <SalesInvoices>
+      <Invoice>
+        <InvoiceNo>FT 1/1</InvoiceNo>
+        <CustomerID>1001</CustomerID>
+      </Invoice>
+      <Invoice>
+        <InvoiceNo>FT 2/1</InvoiceNo>
+        <CustomerID>EXISTING</CustomerID>
+      </Invoice>
+    </SalesInvoices>
+  </SourceDocuments>
+</AuditFile>
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def _create_excel(path: Path) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.append([
+        "Código",
+        "Nome",
+        "Contribuinte",
+        "Localidade",
+        "País",
+        "Telemovel",
+    ])
+    sheet.append([
+        "1001",
+        "Cliente 1001",
+        "245678901",
+        "Luanda",
+        "AO",
+        "923456789",
+    ])
+    workbook.save(path)
+
+
+def test_missing_customer_added_from_excel(tmp_path, monkeypatch):
+    xml_path = tmp_path / "saf-t.xml"
+    excel_path = tmp_path / "clientes.xlsx"
+    _create_sample_xml(xml_path)
+    _create_excel(excel_path)
+
+    monkeypatch.setenv("BWB_SAFTAO_CUSTOMER_FILE", str(excel_path))
+
+    issues = list(ensure_invoice_customers_exported(xml_path))
+
+    assert issues, "should report the addition of the missing customer"
+    assert "Cliente '1001'" in issues[0].message
+    assert issues[0].details["customer_id"] == "1001"
+    assert issues[0].details["source"] == str(excel_path)
+
+    tree = etree.parse(str(xml_path))
+    customers = tree.xpath(
+        ".//n:MasterFiles/n:Customer[n:CustomerID='1001']",
+        namespaces=NS,
+    )
+    assert len(customers) == 1
+    customer = customers[0]
+    assert customer.findtext("n:CustomerTaxID", namespaces=NS) == "245678901"
+    assert customer.findtext("n:CompanyName", namespaces=NS) == "Cliente 1001"
+    assert customer.findtext(
+        "n:BillingAddress/n:City",
+        namespaces=NS,
+    ) == "Luanda"
+    assert customer.findtext("n:Telephone", namespaces=NS) == "923456789"
+    assert customer.findtext("n:SelfBillingIndicator", namespaces=NS) == "0"
+
+
+def test_no_missing_customers_returns_empty(tmp_path, monkeypatch):
+    xml_path = tmp_path / "saf-t.xml"
+    content = f"""<?xml version='1.0' encoding='UTF-8'?>
+<AuditFile xmlns=\"{NAMESPACE}\">
+  <MasterFiles>
+    <Customer>
+      <CustomerID>1001</CustomerID>
+      <AccountID>1001</AccountID>
+      <CustomerTaxID>123456789</CustomerTaxID>
+      <CompanyName>Cliente 1001</CompanyName>
+      <BillingAddress>
+        <AddressDetail>Morada</AddressDetail>
+        <City>Luanda</City>
+        <Country>AO</Country>
+      </BillingAddress>
+      <SelfBillingIndicator>0</SelfBillingIndicator>
+    </Customer>
+  </MasterFiles>
+  <SourceDocuments>
+    <SalesInvoices>
+      <Invoice>
+        <CustomerID>1001</CustomerID>
+      </Invoice>
+    </SalesInvoices>
+  </SourceDocuments>
+</AuditFile>
+"""
+    xml_path.write_text(content, encoding="utf-8")
+
+    monkeypatch.delenv("BWB_SAFTAO_CUSTOMER_FILE", raising=False)
+
+    issues = ensure_invoice_customers_exported(xml_path)
+    assert list(issues) == []
+
+
+def test_default_excel_file_used_when_present(tmp_path, monkeypatch):
+    xml_path = tmp_path / "saf-t.xml"
+    _create_sample_xml(xml_path)
+
+    default_dir = tmp_path / "addons"
+    default_dir.mkdir()
+    default_excel = default_dir / _DEFAULT_CUSTOMER_FILENAME
+    _create_excel(default_excel)
+
+    monkeypatch.delenv("BWB_SAFTAO_CUSTOMER_FILE", raising=False)
+    import saftao.autofix.soft as soft_module
+
+    monkeypatch.setattr(soft_module, "_DEFAULT_ADDONS_DIR", default_dir, raising=False)
+
+    issues = list(ensure_invoice_customers_exported(xml_path))
+
+    assert issues, "should report the addition of the missing customer"
+    assert issues[0].details["source"] == str(default_excel)
+
+
+def test_customer_inserted_before_tax_table(tmp_path, monkeypatch):
+    xml_path = tmp_path / "saf-t.xml"
+    content = f"""<?xml version='1.0' encoding='UTF-8'?>
+<AuditFile xmlns=\"{NAMESPACE}\">
+  <MasterFiles>
+    <GeneralLedgerAccounts />
+    <TaxTable>
+      <TaxTableEntry>
+        <TaxType>IVA</TaxType>
+        <TaxCountryRegion>AO</TaxCountryRegion>
+        <TaxCode>N</TaxCode>
+        <Description>Normal</Description>
+        <TaxPercentage>14</TaxPercentage>
+      </TaxTableEntry>
+    </TaxTable>
+  </MasterFiles>
+  <SourceDocuments>
+    <SalesInvoices>
+      <Invoice>
+        <InvoiceNo>FT 3/1</InvoiceNo>
+        <CustomerID>1001</CustomerID>
+      </Invoice>
+    </SalesInvoices>
+  </SourceDocuments>
+</AuditFile>
+"""
+    xml_path.write_text(content, encoding="utf-8")
+
+    excel_path = tmp_path / "clientes.xlsx"
+    _create_excel(excel_path)
+
+    monkeypatch.setenv("BWB_SAFTAO_CUSTOMER_FILE", str(excel_path))
+
+    issues = list(ensure_invoice_customers_exported(xml_path))
+    assert issues, "expected the missing customer to be added"
+
+    tree = etree.parse(str(xml_path))
+    child_tags = [
+        child.tag.split("}", 1)[-1]
+        for child in tree.xpath("/n:AuditFile/n:MasterFiles/*", namespaces=NS)
+    ]
+
+    assert child_tags == ["GeneralLedgerAccounts", "Customer", "TaxTable"]

--- a/tests/test_invoice_type_normalization.py
+++ b/tests/test_invoice_type_normalization.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lxml import etree
+
+from saftao.autofix.soft import normalize_invoice_type_vd
+
+NAMESPACE = "urn:OECD:StandardAuditFile-Tax:AO_1.01_01"
+NS = {"n": NAMESPACE}
+
+
+def _write_invoice(path: Path, invoice_type: str) -> None:
+    path.write_text(
+        f"""<?xml version='1.0' encoding='UTF-8'?>
+<AuditFile xmlns=\"{NAMESPACE}\">
+  <SourceDocuments>
+    <SalesInvoices>
+      <Invoice>
+        <InvoiceNo>VD 1/1</InvoiceNo>
+        <InvoiceType>{invoice_type}</InvoiceType>
+      </Invoice>
+    </SalesInvoices>
+  </SourceDocuments>
+</AuditFile>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_invoice_type_vd_is_normalised(tmp_path):
+    xml_path = tmp_path / "vd.xml"
+    _write_invoice(xml_path, "VD")
+
+    issues = list(normalize_invoice_type_vd(xml_path))
+
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue.code == "FIX_INVOICE_TYPE"
+    assert issue.details["invoice"] == "VD 1/1"
+
+    tree = etree.parse(str(xml_path))
+    invoice_type = tree.xpath(
+        ".//n:SourceDocuments/n:SalesInvoices/n:Invoice/n:InvoiceType/text()",
+        namespaces=NS,
+    )
+    assert invoice_type == ["FR"]
+
+
+def test_invoice_type_vd_noop_when_not_present(tmp_path):
+    xml_path = tmp_path / "ft.xml"
+    _write_invoice(xml_path, "FR")
+
+    issues = list(normalize_invoice_type_vd(xml_path))
+
+    assert issues == []
+
+    tree = etree.parse(str(xml_path))
+    invoice_type = tree.xpath(
+        ".//n:SourceDocuments/n:SalesInvoices/n:Invoice/n:InvoiceType/text()",
+        namespaces=NS,
+    )
+    assert invoice_type == ["FR"]


### PR DESCRIPTION
## Summary
- ensure auto-added customers are inserted before Supplier/Product/TaxTable entries so the MasterFiles sequence remains schema-compliant
- add regression coverage that verifies the new customer appears before the TaxTable block when created from Excel

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e45244202c8322a078f8b93aeb4c73