### PR TITLE
Ensure Codex markers use Portugal time

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,28 @@
 3. Ao migrar lógica dos scripts antigos, assegure-se de cobrir os novos módulos
    com testes e documentação adequados.
 
+## Registo de alterações efectuadas pelo Codex
+
+Sempre que o Codex adicionar blocos de código deve inserir imediatamente acima
+dos novos trechos a linha de separador
+
+```
+#    -------- adicionado pelo Codex a <timestamp>  --------
+```
+
+utilizando a data e hora de Portugal (fuso horário `Europe/Lisbon`) no formato
+ISO 8601, incluindo o desvio horário, por exemplo
+`2025-10-07T11:37:03+01:00`.
+
+Para remoções de código, acrescente antes da secção eliminada o marcador
+
+```
+#    -------- removido pelo Codex a <timestamp>  --------
+```
+
+também com data e hora de Portugal no mesmo formato. Estes registos facilitam a
+auditoria das alterações automatizadas efectuadas pela ferramenta.
+
 ## Resolução de conflitos de merge no GitHub
 
 Quando o GitHub detecta conflitos num ficheiro (por exemplo, `src/saftao/gui.py`)

--- a/launcher.py
+++ b/launcher.py
@@ -9,11 +9,11 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Callable
-#    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
 from importlib import metadata as importlib_metadata
-#    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
 from packaging.markers import default_environment
-#    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
 from packaging.requirements import Requirement
 
 Command = Callable[[], int | None]
@@ -55,7 +55,7 @@ def _read_requirements(requirements_path: Path) -> list[str]:
     return requirements
 
 
-#    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
 def _missing_requirements(requirements: list[str]) -> list[str]:
     """Return requirements that are not satisfied in the current environment."""
 

--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -17,9 +17,9 @@ import sys
 from functools import partial
 from pathlib import Path
 from typing import Iterable, Mapping
-#    -------- adicionado pelo Codex a 2025-10-07T10:01:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
 from saftao.ui import qt_bootstrap
-#    -------- adicionado pelo Codex a 2025-10-07T10:01:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
 from PySide6.QtCore import (
     QObject,
     QSettings,
@@ -30,9 +30,9 @@ from PySide6.QtCore import (
     Signal,
     Slot,
 )
-#    -------- adicionado pelo Codex a 2025-10-07T10:01:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
 from PySide6.QtGui import QAction, QPainter, QPixmap, QTextCursor
-#    -------- adicionado pelo Codex a 2025-10-07T10:01:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
 from PySide6.QtWidgets import (
     QFileDialog,
     QFormLayout,

--- a/src/saftao/ui/qt_bootstrap.py
+++ b/src/saftao/ui/qt_bootstrap.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
-#    -------- adicionado pelo Codex a 2025-10-07T10:19:53Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:19:53+01:00  --------
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -30,7 +30,7 @@ _PLUGIN_SUFFIXES = {".dll", ".dylib", ".so"}
 _DISCOVERED_PLUGIN_PATHS: tuple[Path, Path] | None = None
 
 
-#    -------- adicionado pelo Codex a 2025-10-07T10:19:53Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:19:53+01:00  --------
 def _merge_env_paths(variable: str, *paths: Path) -> str:
     """Anexe *paths* ao valor da variável de ambiente sem duplicados."""
 
@@ -144,7 +144,7 @@ def _discover_platform_plugin_dirs(
 
 
 def _set_qt_plugin_environment(plugin_root: Path, platform_dir: Path) -> None:
-    #    -------- adicionado pelo Codex a 2025-10-07T10:19:53Z  --------
+    #    -------- adicionado pelo Codex a 2025-10-07T11:19:53+01:00  --------
     qt_plugin_path = _merge_env_paths("QT_PLUGIN_PATH", plugin_root)
     qt_platform_path = _merge_env_paths(
         "QT_QPA_PLATFORM_PLUGIN_PATH", platform_dir
@@ -152,7 +152,7 @@ def _set_qt_plugin_environment(plugin_root: Path, platform_dir: Path) -> None:
     LOGGER.info("QT_PLUGIN_PATH ajustado para %s", qt_plugin_path)
     LOGGER.info("QT_QPA_PLATFORM_PLUGIN_PATH ajustado para %s", qt_platform_path)
 
-    #    -------- adicionado pelo Codex a 2025-10-07T10:19:53Z  --------
+    #    -------- adicionado pelo Codex a 2025-10-07T11:19:53+01:00  --------
     if sys.platform == "darwin":
         frameworks_dir = plugin_root.parent / "lib"
         if frameworks_dir.exists():
@@ -167,7 +167,7 @@ def _set_qt_plugin_environment(plugin_root: Path, platform_dir: Path) -> None:
                 "Directório de frameworks Qt não encontrado em %s", frameworks_dir
             )
 
-    #    -------- adicionado pelo Codex a 2025-10-07T10:19:53Z  --------
+    #    -------- adicionado pelo Codex a 2025-10-07T11:19:53+01:00  --------
     cocoa_plugin = platform_dir / "libqcocoa.dylib"
     if cocoa_plugin.exists():
         LOGGER.info("Plugin 'libqcocoa.dylib' encontrado em %s", cocoa_plugin)

--- a/tests/test_launcher_requirements.py
+++ b/tests/test_launcher_requirements.py
@@ -14,7 +14,7 @@ def test_ensure_requirements_no_missing(tmp_path, monkeypatch):
 
     calls: list[list[str]] = []
 
-    #    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+    #    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
     def fake_missing(requirements: list[str]) -> list[str]:
         calls.append(requirements)
         return []
@@ -40,7 +40,7 @@ def test_ensure_requirements_installs_missing(tmp_path, monkeypatch):
 
     install_triggered = False
 
-    #    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+    #    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
     def fake_missing(requirements: list[str]) -> list[str]:
         nonlocal install_triggered
         if install_triggered:
@@ -68,7 +68,7 @@ def test_ensure_requirements_install_failure(tmp_path, monkeypatch):
     req_file = tmp_path / "requirements.txt"
     req_file.write_text("foo==1.0\n", encoding="utf-8")
 
-    #    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+    #    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
     def fake_missing(requirements: list[str]) -> list[str]:
         return ["foo==1.0"]
 
@@ -83,7 +83,7 @@ def test_ensure_requirements_install_failure(tmp_path, monkeypatch):
         launcher.ensure_requirements(req_file)
 
 
-#    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
 def test_missing_requirements_detects_absent_package(monkeypatch):
     def fake_version(_name: str) -> str:
         raise launcher.importlib_metadata.PackageNotFoundError
@@ -95,7 +95,7 @@ def test_missing_requirements_detects_absent_package(monkeypatch):
     assert missing == ["foo==1.0"]
 
 
-#    -------- adicionado pelo Codex a 2025-10-07T10:37:03Z  --------
+#    -------- adicionado pelo Codex a 2025-10-07T11:37:03+01:00  --------
 def test_missing_requirements_accepts_matching_version(monkeypatch):
     def fake_version(_name: str) -> str:
         return "1.0"


### PR DESCRIPTION
## Summary
- switch the Codex separator comments to Portugal (Europe/Lisbon) timestamps across launcher, GUI and Qt bootstrap modules and their tests
- document the requirement to use Portugal time for Codex additions and add the new removal marker guideline in the contributing guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f15494108322805bc04bab83a246