### PR TITLE
Fix Qt bootstrap import order for PySide6 initialization

### DIFF
--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -18,6 +18,13 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Iterable, Mapping
 
+# Nota: ``qt_bootstrap`` deve ser importado antes de qualquer módulo PySide6,
+# garantindo que as variáveis de ambiente dos plugins Qt são configuradas
+# antes da inicialização da biblioteca Qt. Sem esta ordem, o Qt pode ignorar as
+# variáveis ``QT_PLUGIN_PATH`` definidas dinamicamente, resultando em erros a
+# carregar o plugin "cocoa" no macOS.
+from saftao.ui import qt_bootstrap
+
 #    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
 from PySide6.QtCore import (
     QObject,
@@ -53,9 +60,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-
-#    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
-from saftao.ui import qt_bootstrap
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"


### PR DESCRIPTION
## Summary
- ensure the Qt plugin bootstrap module is imported before any PySide6 modules
- document why the bootstrap import order matters to keep Qt plugin paths active on macOS

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f6f62f3c8322807b93fa52ce7479