### PR TITLE
Ensure Qt platform plugin path is set in launcher

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import os
 import subprocess
 import sys
 from importlib import metadata as importlib_metadata
@@ -15,6 +16,18 @@ SRC_DIR = PROJECT_ROOT / "src"
 
 if SRC_DIR.is_dir():
     sys.path.insert(0, str(SRC_DIR))
+
+
+# --- Qt plugin path fix for macOS (PySide6/Qt6) ---
+if "QT_QPA_PLATFORM_PLUGIN_PATH" not in os.environ:
+    try:
+        import PySide6
+    except Exception:  # pragma: no cover - defensive guard for optional dependency
+        pass
+    else:
+        plugin_dir = Path(PySide6.__file__).with_name("Qt") / "plugins" / "platforms"
+        os.environ.setdefault("QT_QPA_PLATFORM_PLUGIN_PATH", str(plugin_dir))
+# ---------------------------------------------------
 
 
 COMMANDS: dict[str, tuple[str, str, str]] = {

--- a/src/saftao/gui.py
+++ b/src/saftao/gui.py
@@ -18,6 +18,13 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Iterable, Mapping
 
+# Nota: ``qt_bootstrap`` deve ser importado antes de qualquer módulo PySide6,
+# garantindo que as variáveis de ambiente dos plugins Qt são configuradas
+# antes da inicialização da biblioteca Qt. Sem esta ordem, o Qt pode ignorar as
+# variáveis ``QT_PLUGIN_PATH`` definidas dinamicamente, resultando em erros a
+# carregar o plugin "cocoa" no macOS.
+from saftao.ui import qt_bootstrap
+
 #    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
 from PySide6.QtCore import (
     QObject,
@@ -53,9 +60,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-
-#    -------- adicionado pelo Codex a 2025-10-07T11:01:03+01:00  --------
-from saftao.ui import qt_bootstrap
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"


### PR DESCRIPTION
## Summary
- set QT_QPA_PLATFORM_PLUGIN_PATH in launcher before any PySide6 usage to ensure the macOS Cocoa plugin is available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f6f62f3c8322807b93fa52ce7479