### PR TITLE
Ensure Qt plugin path is set before PySide6 imports

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+# -- fix Qt plugins on macOS (venv) --
+import os
+import pathlib
+
+try:
+    import PySide6  # type: ignore
+except ModuleNotFoundError:
+    PySide6 = None  # type: ignore[assignment]
+else:  # pragma: no branch - simple happy path
+    plugins = pathlib.Path(PySide6.__file__).with_name("Qt") / "plugins" / "platforms"
+    os.environ.setdefault("QT_QPA_PLATFORM_PLUGIN_PATH", str(plugins))
+# ------------------------------------
+
 import argparse
 import importlib
-import os
 import subprocess
 import sys
 from importlib import metadata as importlib_metadata


### PR DESCRIPTION
## Summary
- set the QT_QPA_PLATFORM_PLUGIN_PATH environment variable from the PySide6 installation at startup
- guard the early PySide6 import to avoid failures when the dependency is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50234c9e083228ff8e4cd6ce8ef46