### PR TITLE
Fix missing sys import in launcher

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -16,6 +16,7 @@ else:  # pragma: no branch - simple happy path
 import argparse
 import importlib
 import subprocess
+import sys
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any, Callable


### PR DESCRIPTION
## Summary
- import the sys module before referencing it in the launcher entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e51365297c8322aab9349ff49ad80f