### PR TITLE
Add Apple Silicon support to macOS build workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -5,7 +5,18 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - runner: macos-13
+            python-arch: x64
+            artifact-suffix: x64
+            archflags: "-arch x86_64"
+          - runner: macos-14
+            python-arch: arm64
+            artifact-suffix: arm64
+            archflags: "-arch arm64"
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -13,6 +24,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          architecture: ${{ matrix.python-arch }}
 
       - name: Install dependencies
         run: |
@@ -23,10 +35,11 @@ jobs:
       - name: Build .app
         env:
           PYTHONPATH: src
+          ARCHFLAGS: ${{ matrix.archflags }}
         run: python setup.py py2app
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Verificador_SAFT_AO.app
+          name: Verificador_SAFT_AO_${{ matrix.artifact-suffix }}.app
           path: 'dist/Verificador SAFT-AO.app'


### PR DESCRIPTION
## Summary
- run the macOS build job on both Intel and Apple Silicon runners
- configure the Python architecture and ARCHFLAGS for each platform
- upload architecture-specific application artifacts

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e548193a8483228201c6071af1d803