### PR TITLE
Bundle PySide6 assets in macOS build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
-          pip install py2app
+          pip install py2app py2app-recipes
 
       - name: Build .app (py2app)
         env:


### PR DESCRIPTION
## Summary
- install py2app-recipes in the macOS packaging workflow alongside py2app
- extend the py2app configuration to collect PySide6 frameworks and plugins so the bundled app includes the Qt Cocoa backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e553273a488322a9511296b15b79d7