### PR TITLE
Fix macOS packaging workflow dependency failure

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
-          pip install py2app py2app-recipes
+          # ``py2app-recipes`` não é distribuído no PyPI; basta instalar o py2app.
+          pip install py2app
 
       - name: Build .app (py2app)
         env:


### PR DESCRIPTION
## Summary
- remove the py2app-recipes install from the macOS workflow because the package is not published on PyPI
- ensure the workflow installs py2app successfully so the .app bundle can be produced

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e565e54a9c83228c7b074c994e8ef7