### PR TITLE
Fix macOS artifact zip to keep .app bundle

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -49,10 +49,15 @@ jobs:
           echo "Listing dist/:"
           ls -la "dist"
 
-      # ✅ Faz upload do bundle .app como diretório; o GitHub trata do zip.
+      # ``ditto --keepParent`` garante que o bundle ``.app`` é preservado ao descompactar.
+      - name: Empacotar .app em .zip
+        run: |
+          cd dist
+          ditto -c -k --sequesterRsrc --keepParent "Verificador SAFT-AO.app" "Verificador_SAFT_AO_${{ matrix.artifact-suffix }}.zip"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Verificador_SAFT_AO_${{ matrix.artifact-suffix }}.app
-          path: dist/Verificador SAFT-AO.app
+          name: Verificador_SAFT_AO_${{ matrix.artifact-suffix }}.zip
+          path: dist/Verificador_SAFT_AO_${{ matrix.artifact-suffix }}.zip
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- package the generated macOS bundle with `ditto --keepParent` so the .app directory is preserved when unzipped
- upload the pre-zipped artifact instead of relying on the implicit compression from upload-artifact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e584cd18ac8322b63f9ad13210ba8a