### PR TITLE
Use PNG asset for application icon

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include src/saftao *.svg
+recursive-include src/saftao *.png

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ IDENTIFIER = "ao.bwb.verificador-saft"
 SCHEMA_DIR = Path("schemas")
 RESOURCES = [str(SCHEMA_DIR)] if SCHEMA_DIR.exists() else []
 
-ICON_FILE = Path("src/saftao/bwb-saft-app.svg")
+ICON_FILE = Path("src/saftao/bwb-saft-app.png")
 if ICON_FILE.exists():
     RESOURCES.append(str(ICON_FILE))
 

--- a/src/saftao/ui/app_launcher.py
+++ b/src/saftao/ui/app_launcher.py
@@ -78,7 +78,7 @@ QWidget#splash-overlay {
 }
 """
 
-APP_ICON_PATH = Path(__file__).resolve().parents[1] / "bwb-saft-app.svg"
+APP_ICON_PATH = Path(__file__).resolve().parents[1] / "bwb-saft-app.png"
 
 __all__ = [
     "APP_STYLESHEET",


### PR DESCRIPTION
## Summary
- update the Qt application launcher to load the packaged PNG icon
- adjust packaging metadata to include the PNG asset when building

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5865bf8248322aae57978ac3b8a8e