### PR TITLE
fix: default tax country region for working documents

### DIFF
--- a/src/saftao/commands/autofix_hard.py
+++ b/src/saftao/commands/autofix_hard.py
@@ -334,6 +334,18 @@ def fix_xml(tree: etree._ElementTree, path: Path) -> etree._ElementTree:
                 continue
             ensure_tax_country_region(tax, nsuri)
 
+    work_docs = root.findall(
+        ".//n:SourceDocuments/n:WorkingDocuments/n:WorkDocument",
+        namespaces=ns,
+    )
+    for work_doc in work_docs:
+        lines = work_doc.findall("./n:Line", namespaces=ns)
+        for line in lines:
+            tax = line.find("./n:Tax", namespaces=ns)
+            if tax is None:
+                continue
+            ensure_tax_country_region(tax, nsuri)
+
     return tree
 
 

--- a/src/saftao/commands/autofix_soft.py
+++ b/src/saftao/commands/autofix_soft.py
@@ -664,6 +664,29 @@ def fix_xml(
                 xpath=line_xpath,
             )
 
+    work_docs = root.findall(
+        ".//n:SourceDocuments/n:WorkingDocuments/n:WorkDocument",
+        namespaces=ns,
+    )
+    for work_doc in work_docs:
+        doc_no = get_text(
+            work_doc.find("./n:DocumentNumber", namespaces=ns)
+        ) or ""
+        lines = work_doc.findall("./n:Line", namespaces=ns)
+        for idx, line in enumerate(lines, start=1):
+            line_xpath = etree.ElementTree(root).getpath(line)
+            tax = line.find("./n:Tax", namespaces=ns)
+            if tax is None:
+                continue
+            ensure_tax_country_region(
+                tax,
+                nsuri,
+                logger,
+                owner=doc_no,
+                line=idx,
+                xpath=line_xpath,
+            )
+
     try:
         customer_issues = ensure_invoice_customers_exported_tree(tree)
     except Exception as exc:

--- a/tests/test_tax_country_region.py
+++ b/tests/test_tax_country_region.py
@@ -95,6 +95,28 @@ def _build_xml() -> str:
         </Line>
       </Payment>
     </Payments>
+    <WorkingDocuments>
+      <WorkDocument>
+        <DocumentNumber>CM 1</DocumentNumber>
+        <Line>
+          <LineNumber>1</LineNumber>
+          <Tax>
+            <TaxType>IVA</TaxType>
+            <TaxCode>NOR</TaxCode>
+            <TaxPercentage>14.00</TaxPercentage>
+          </Tax>
+        </Line>
+        <Line>
+          <LineNumber>2</LineNumber>
+          <Tax>
+            <TaxType>IVA</TaxType>
+            <TaxCode>NOR</TaxCode>
+            <TaxCountryRegion>PT</TaxCountryRegion>
+            <TaxPercentage>14.00</TaxPercentage>
+          </Tax>
+        </Line>
+      </WorkDocument>
+    </WorkingDocuments>
   </SourceDocuments>
 </AuditFile>
 """
@@ -137,6 +159,14 @@ def test_soft_fix_adds_tax_country_region_in_all_tax_blocks():
         tree,
         ".//n:Payments/n:Payment/n:Line[n:LineNumber='2']/n:Tax/n:TaxCountryRegion/text()",
     ) == ["PT"]
+    assert _xpath(
+        tree,
+        ".//n:WorkingDocuments/n:WorkDocument[n:DocumentNumber='CM 1']/n:Line[n:LineNumber='1']/n:Tax/n:TaxCountryRegion/text()",
+    ) == ["AO"]
+    assert _xpath(
+        tree,
+        ".//n:WorkingDocuments/n:WorkDocument/n:Line[n:LineNumber='2']/n:Tax/n:TaxCountryRegion/text()",
+    ) == ["PT"]
 
 
 def test_hard_fix_preserves_foreign_tax_country_region_and_defaults_to_ao():
@@ -164,4 +194,12 @@ def test_hard_fix_preserves_foreign_tax_country_region_and_defaults_to_ao():
     assert _xpath(
         tree,
         ".//n:Payments/n:Payment/n:Line[n:LineNumber='2']/n:Tax/n:TaxCountryRegion/text()",
+    ) == ["PT"]
+    assert _xpath(
+        tree,
+        ".//n:WorkingDocuments/n:WorkDocument[n:DocumentNumber='CM 1']/n:Line[n:LineNumber='1']/n:Tax/n:TaxCountryRegion/text()",
+    ) == ["AO"]
+    assert _xpath(
+        tree,
+        ".//n:WorkingDocuments/n:WorkDocument/n:Line[n:LineNumber='2']/n:Tax/n:TaxCountryRegion/text()",
     ) == ["PT"]


### PR DESCRIPTION
## Summary
- ensure both soft and hard autofix routines inject a default TaxCountryRegion for WorkingDocument tax lines
- extend the TaxCountryRegion regression test fixture and assertions to cover WorkingDocuments alongside invoices and payments

## Testing
- pytest tests/test_tax_country_region.py

------
https://chatgpt.com/codex/tasks/task_e_68e655d38f748322850617520fd63e43