### PR TITLE
Document fallback NIF rules for customers without tax IDs

### DIFF
--- a/docs/regras_tecnico_agt_saft-ao.md
+++ b/docs/regras_tecnico_agt_saft-ao.md
@@ -50,7 +50,13 @@ esquema para gerar validações automáticas.
 ## Validações adicionais recomendadas
 
 - Validar NIF (9 dígitos) com algoritmo de controlo da AGT antes de
-  exportar clientes e fornecedores.
+  exportar clientes e fornecedores. Quando não existir um NIF válido
+  para o comprador final, utilizar o identificador genérico
+  `999999990`, reservado pela AGT para vendas a dinheiro e clientes
+  ocasionais. Em operações com entidades estrangeiras, prefixar o NIF
+  com o código ISO alfa-2 do país (por exemplo `PT123456789` ou
+  `CN000000000`) e garantir que os campos `Country` e `CustomerTaxID`
+  reflectem essa origem.
 - Verificar limites do XSD (tamanho máximo de campos, enumerados de
   códigos de imposto, `InvoiceType`, `MovementType`, etc.).
 - Incluir testes automáticos que comparem o XML gerado com exemplos


### PR DESCRIPTION
## Summary
- document the AGT-approved fallback NIFs for cash sales and foreign customers in the technical rules reference

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e6622522e883229f40c3027a73507c