### PR TITLE
Detect and fix SAF-T namespace and tax registration issues

### DIFF
--- a/docs/regras_tecnico_agt_saft-ao.md
+++ b/docs/regras_tecnico_agt_saft-ao.md
@@ -50,7 +50,13 @@ esquema para gerar validações automáticas.
 ## Validações adicionais recomendadas
 
 - Validar NIF (9 dígitos) com algoritmo de controlo da AGT antes de
-  exportar clientes e fornecedores.
+  exportar clientes e fornecedores. Quando não existir um NIF válido
+  para o comprador final, utilizar o identificador genérico
+  `999999990`, reservado pela AGT para vendas a dinheiro e clientes
+  ocasionais. Em operações com entidades estrangeiras, prefixar o NIF
+  com o código ISO alfa-2 do país (por exemplo `PT123456789` ou
+  `CN000000000`) e garantir que os campos `Country` e `CustomerTaxID`
+  reflectem essa origem.
 - Verificar limites do XSD (tamanho máximo de campos, enumerados de
   códigos de imposto, `InvoiceType`, `MovementType`, etc.).
 - Incluir testes automáticos que comparem o XML gerado com exemplos

--- a/src/saftao/autofix/_header.py
+++ b/src/saftao/autofix/_header.py
@@ -1,0 +1,31 @@
+"""Helpers for normalising header information."""
+
+from __future__ import annotations
+
+from lxml import etree
+
+
+def normalise_tax_registration_number(
+    root: etree._Element, namespace: str
+) -> tuple[bool, str, str]:
+    """Strip non-digit characters from ``TaxRegistrationNumber``."""
+
+    ns = {"n": namespace}
+    header = root.find(".//n:Header", namespaces=ns)
+    if header is None:
+        return False, "", ""
+
+    trn = header.find("./n:TaxRegistrationNumber", namespaces=ns)
+    if trn is None:
+        return False, "", ""
+
+    current = (trn.text or "").strip()
+    digits_only = "".join(ch for ch in current if ch.isdigit())
+    if not digits_only or digits_only == current:
+        return False, current, digits_only
+
+    trn.text = digits_only
+    return True, current, digits_only
+
+
+__all__ = ["normalise_tax_registration_number"]

--- a/src/saftao/autofix/_namespace.py
+++ b/src/saftao/autofix/_namespace.py
@@ -1,0 +1,81 @@
+"""Namespace normalisation utilities for MasterFiles customers."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from lxml import etree
+
+
+def _subtree_has_prefixed_nodes(node: etree._Element, namespace: str) -> bool:
+    """Return ``True`` if any element in ``node`` uses a prefixed tag."""
+
+    for element in node.iter():
+        qname = etree.QName(element)
+        if qname.namespace == namespace and element.prefix:
+            return True
+    return False
+
+
+def _clone_with_namespace(node: etree._Element, namespace: str) -> etree._Element:
+    """Clone ``node`` ensuring every tag belongs to the default namespace."""
+
+    qname = etree.QName(node)
+    cloned = etree.Element(f"{{{namespace}}}{qname.localname}")
+    cloned.text = node.text
+    cloned.tail = node.tail
+
+    for attr_name, value in node.attrib.items():
+        attr_qname = etree.QName(attr_name)
+        if attr_qname.namespace:
+            cloned.attrib[f"{{{attr_qname.namespace}}}{attr_qname.localname}"] = value
+        else:
+            cloned.attrib[attr_qname.localname] = value
+
+    for child in node:
+        cloned.append(_clone_with_namespace(child, namespace))
+
+    return cloned
+
+
+def normalise_customer_namespace(
+    root: etree._Element, namespace: str, *, on_fix: Callable[[str], None] | None = None
+) -> bool:
+    """Rewrite ``Customer`` blocks so that they use the default namespace."""
+
+    ns = {"n": namespace}
+    masterfiles = root.find(".//n:MasterFiles", namespaces=ns)
+    if masterfiles is None:
+        return False
+
+    changed = False
+    customers = masterfiles.findall(f"./{{{namespace}}}Customer")
+    for customer in customers:
+        if not _subtree_has_prefixed_nodes(customer, namespace):
+            continue
+
+        customer_id_el = customer.find(f"./{{{namespace}}}CustomerID")
+        if customer_id_el is None:
+            customer_id_el = customer.find("./*[local-name()='CustomerID']")
+        customer_id = (customer_id_el.text or "").strip() if customer_id_el is not None else ""
+
+        parent = customer.getparent()
+        if parent is None:
+            continue
+
+        replacement = _clone_with_namespace(customer, namespace)
+        index = parent.index(customer)
+        parent.remove(customer)
+        parent.insert(index, replacement)
+        changed = True
+
+        if on_fix is not None:
+            on_fix(customer_id)
+
+    if changed:
+        etree.cleanup_namespaces(root)
+
+    return changed
+
+
+__all__ = ["normalise_customer_namespace"]

--- a/src/saftao/validator.py
+++ b/src/saftao/validator.py
@@ -1,20 +1,17 @@
-"""Validator entry point for SAFT AO files.
-
-This module will eventually house the refactored logic currently present in
-``validator_saft_ao.py``.  For now, it provides stub classes and functions
-that define the intended public surface.
-"""
+"""Validator entry point for SAFT AO files."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
 
-from .logging import ExcelLogger, ExcelLoggerConfig
+from lxml import etree
+
+from .utils import detect_namespace
 
 
 class ValidationIssue:
-    """Placeholder representation of a problem detected during validation."""
+    """Representation of a problem detected during validation."""
 
     def __init__(
         self,
@@ -34,23 +31,234 @@ class ValidationIssue:
 
 
 def validate_file(path: Path) -> Iterable[ValidationIssue]:
-    """Validate the provided file.
+    """Validate the provided file and return the detected issues."""
 
-    The implementation is pending the migration of the existing validator
-    script into the package structure.
-    """
+    tree = etree.parse(str(path))
+    return validate_tree(tree)
 
-    raise NotImplementedError("Validator logic not yet ported to the package")
+
+def validate_tree(tree: etree._ElementTree) -> list[ValidationIssue]:
+    """Run the validation checks against an in-memory XML tree."""
+
+    root = tree.getroot()
+    namespace = detect_namespace(root)
+
+    issues: list[ValidationIssue] = []
+
+    customer_issues, valid_customers, prefixed_customers = _check_masterfile_customers(
+        root, namespace
+    )
+    issues.extend(customer_issues)
+    issues.extend(
+        _check_invoice_customer_references(
+            root, namespace, valid_customers, prefixed_customers
+        )
+    )
+    issues.extend(_check_tax_registration_number(root, namespace))
+    issues.extend(_check_tax_country_region(root, namespace))
+
+    return issues
 
 
 def export_report(issues: Iterable[ValidationIssue], *, destination: Path) -> None:
-    """Export validation issues to an Excel report.
+    """Export validation issues to an Excel report."""
 
-    This helper demonstrates how the shared logger will be used once the
-    underlying logic is refactored.
-    """
+    from .logging import ExcelLogger, ExcelLoggerConfig
 
     logger = ExcelLogger(
         ExcelLoggerConfig(columns=("code", "message"), filename=str(destination))
     )
     logger.write_rows(issues)
+
+
+def _check_masterfile_customers(
+    root: etree._Element, namespace: str
+) -> tuple[list[ValidationIssue], set[str], set[str]]:
+    ns = {"n": namespace}
+    masterfiles = root.find(".//n:MasterFiles", namespaces=ns)
+    if masterfiles is None:
+        return [], set(), set()
+
+    issues: list[ValidationIssue] = []
+    valid_ids: set[str] = set()
+    prefixed_ids: set[str] = set()
+
+    for customer in masterfiles.findall(f"./{{{namespace}}}Customer"):
+        customer_id = _extract_customer_id(customer, namespace)
+        has_prefix = _subtree_has_prefixed_nodes(customer, namespace)
+        if has_prefix:
+            prefixed_ids.add(customer_id)
+            issues.append(
+                ValidationIssue(
+                    "Customer no MasterFiles exportado com prefixo de namespace (ns:).",
+                    code="CUSTOMER_WRONG_NAMESPACE",
+                    details={"customer_id": customer_id},
+                )
+            )
+        elif customer_id:
+            valid_ids.add(customer_id)
+
+    return issues, valid_ids, prefixed_ids
+
+
+def _check_invoice_customer_references(
+    root: etree._Element,
+    namespace: str,
+    valid_ids: set[str],
+    prefixed_ids: set[str],
+) -> list[ValidationIssue]:
+    ns = {"n": namespace}
+    issues: list[ValidationIssue] = []
+
+    invoices = root.findall(
+        ".//n:SourceDocuments/n:SalesInvoices/n:Invoice", namespaces=ns
+    )
+    for invoice in invoices:
+        customer_el = invoice.find("./n:CustomerID", namespaces=ns)
+        if customer_el is None:
+            continue
+        customer_id = (customer_el.text or "").strip()
+        if not customer_id or customer_id in valid_ids:
+            continue
+
+        invoice_no = _find_child_text(invoice, namespace, "InvoiceNo") or "(sem número)"
+        message = (
+            f"Fatura '{invoice_no}' referencia CustomerID '{customer_id}' que não existe no MasterFiles."
+        )
+        note = (
+            "CustomerID presente no MasterFiles mas com prefixo de namespace não padrão"
+            if customer_id in prefixed_ids
+            else "CustomerID não encontrado"
+        )
+        issues.append(
+            ValidationIssue(
+                message,
+                code="INVOICE_CUSTOMER_MISSING",
+                details={
+                    "invoice": invoice_no,
+                    "customer_id": customer_id,
+                    "note": note,
+                },
+            )
+        )
+
+    return issues
+
+
+def _check_tax_registration_number(
+    root: etree._Element, namespace: str
+) -> list[ValidationIssue]:
+    ns = {"n": namespace}
+    header = root.find(".//n:Header", namespaces=ns)
+    if header is None:
+        return []
+
+    tax_el = header.find("./n:TaxRegistrationNumber", namespaces=ns)
+    if tax_el is None:
+        return []
+
+    value = (tax_el.text or "").strip()
+    if not value or value.isdigit():
+        return []
+
+    digits_only = "".join(ch for ch in value if ch.isdigit())
+    return [
+        ValidationIssue(
+            "TaxRegistrationNumber deve conter apenas dígitos (sem prefixos como 'AO').",
+            code="HEADER_TAX_ID_INVALID",
+            details={"current_value": value, "suggested_value": digits_only},
+        )
+    ]
+
+
+def _check_tax_country_region(root: etree._Element, namespace: str) -> list[ValidationIssue]:
+    ns = {"n": namespace}
+    issues: list[ValidationIssue] = []
+
+    tax_nodes = root.xpath(
+        ".//n:SourceDocuments//*[local-name()='Tax']",
+        namespaces=ns,
+    )
+    for tax in tax_nodes:
+        region = tax.find(f"./{{{namespace}}}TaxCountryRegion")
+        if region is not None and (region.text or "").strip():
+            continue
+
+        doc_type, doc_id, line_no = _resolve_tax_context(tax, namespace)
+        context_parts = [doc_type]
+        if doc_id:
+            context_parts[-1] = f"{doc_type} '{doc_id}'" if doc_type else doc_id
+        if line_no:
+            context_parts.append(f"linha {line_no}")
+        context = ", ".join(part for part in context_parts if part)
+        if not context:
+            context = "Tax"
+
+        issues.append(
+            ValidationIssue(
+                f"TaxCountryRegion em {context} está em falta ou vazio.",
+                code="TAX_COUNTRY_REGION_MISSING",
+                details={
+                    "document_type": doc_type,
+                    "document_id": doc_id,
+                    "line": line_no,
+                },
+            )
+        )
+
+    return issues
+
+
+def _resolve_tax_context(
+    tax: etree._Element, namespace: str
+) -> tuple[str, str, str]:
+    line = tax.getparent()
+    line_no = ""
+    if line is not None:
+        line_no = _find_child_text(line, namespace, "LineNumber") or ""
+
+    parent = line.getparent() if line is not None else None
+    while parent is not None:
+        local = etree.QName(parent).localname
+        if local == "Invoice":
+            return local, _find_child_text(parent, namespace, "InvoiceNo") or "", line_no
+        if local == "Payment":
+            return local, _find_child_text(parent, namespace, "PaymentRefNo") or "", line_no
+        if local == "WorkDocument":
+            return (
+                local,
+                _find_child_text(parent, namespace, "DocumentNumber") or "",
+                line_no,
+            )
+        parent = parent.getparent()
+
+    return "", "", line_no
+
+
+def _find_child_text(
+    element: etree._Element, namespace: str, tag: str
+) -> str | None:
+    child = element.find(f"./{{{namespace}}}{tag}")
+    if child is None:
+        child = element.find(f"./*[local-name()='{tag}']")
+    if child is None:
+        return None
+    return (child.text or "").strip()
+
+
+def _extract_customer_id(customer: etree._Element, namespace: str) -> str:
+    node = customer.find(f"./{{{namespace}}}CustomerID")
+    if node is None:
+        node = customer.find("./*[local-name()='CustomerID']")
+    return (node.text or "").strip() if node is not None else ""
+
+
+def _subtree_has_prefixed_nodes(node: etree._Element, namespace: str) -> bool:
+    for element in node.iter():
+        qname = etree.QName(element)
+        if qname.namespace == namespace and element.prefix:
+            return True
+    return False
+
+
+__all__ = ["ValidationIssue", "validate_file", "validate_tree", "export_report"]

--- a/tests/test_customer_namespace_autofix.py
+++ b/tests/test_customer_namespace_autofix.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lxml import etree
+
+from saftao.commands import autofix_hard, autofix_soft
+
+NAMESPACE = "urn:OECD:StandardAuditFile-Tax:AO_1.01_01"
+NS = {"n": NAMESPACE}
+
+
+class _DummyLogger:
+    def __init__(self) -> None:
+        self.records: list[tuple[tuple, dict]] = []
+
+    def log(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+        self.records.append((args, kwargs))
+
+
+def _build_xml_tree() -> etree._ElementTree:
+    xml = f"""<?xml version='1.0' encoding='UTF-8'?>
+<AuditFile xmlns=\"{NAMESPACE}\" xmlns:ns=\"{NAMESPACE}\">
+  <Header>
+    <TaxRegistrationNumber>AO123456789</TaxRegistrationNumber>
+  </Header>
+  <MasterFiles>
+    <ns:Customer>
+      <ns:CustomerID>1000</ns:CustomerID>
+      <ns:CustomerTaxID>999999990</ns:CustomerTaxID>
+      <ns:CompanyName>Cliente Teste</ns:CompanyName>
+      <ns:SelfBillingIndicator>0</ns:SelfBillingIndicator>
+    </ns:Customer>
+  </MasterFiles>
+  <SourceDocuments>
+    <SalesInvoices>
+      <Invoice>
+        <InvoiceNo>FT 1/1</InvoiceNo>
+        <CustomerID>1000</CustomerID>
+        <Line>
+          <LineNumber>1</LineNumber>
+          <Tax>
+            <TaxType>IVA</TaxType>
+            <TaxCode>NOR</TaxCode>
+          </Tax>
+        </Line>
+      </Invoice>
+    </SalesInvoices>
+  </SourceDocuments>
+</AuditFile>
+"""
+    return etree.ElementTree(etree.fromstring(xml.encode("utf-8")))
+
+
+def _assert_namespace_normalised(root: etree._Element) -> None:
+    customers = root.xpath(".//n:MasterFiles/n:Customer", namespaces=NS)
+    assert customers, "expected a customer element"
+    for customer in customers:
+        for element in customer.iter():
+            qname = etree.QName(element)
+            if qname.namespace == NAMESPACE:
+                assert element.prefix is None
+
+
+def _assert_tax_country_region(root: etree._Element) -> None:
+    values = root.xpath(
+        ".//n:SourceDocuments//n:Tax/n:TaxCountryRegion/text()",
+        namespaces=NS,
+    )
+    assert values == ["AO"]
+
+
+def test_soft_autofix_normalises_customer_and_tax_registration(tmp_path):
+    tree = _build_xml_tree()
+    logger = _DummyLogger()
+
+    autofix_soft.fix_xml(tree, Path(tmp_path / "dummy.xml"), logger)
+
+    root = tree.getroot()
+    _assert_namespace_normalised(root)
+    _assert_tax_country_region(root)
+
+    tax_value = root.xpath(
+        "string(.//n:Header/n:TaxRegistrationNumber)",
+        namespaces=NS,
+    )
+    assert tax_value == "123456789"
+
+    codes = [record[0][0] for record in logger.records]
+    assert "FIX_CUSTOMER_NAMESPACE" in codes
+    assert "FIX_TAX_REGISTRATION" in codes
+
+
+def test_hard_autofix_normalises_customer_and_tax_registration(tmp_path):
+    tree = _build_xml_tree()
+
+    autofix_hard.fix_xml(tree, Path(tmp_path / "dummy.xml"))
+
+    root = tree.getroot()
+    _assert_namespace_normalised(root)
+    _assert_tax_country_region(root)
+
+    tax_value = root.xpath(
+        "string(.//n:Header/n:TaxRegistrationNumber)",
+        namespaces=NS,
+    )
+    assert tax_value == "123456789"

--- a/tests/test_validator_detection.py
+++ b/tests/test_validator_detection.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from saftao.validator import validate_file
+
+NAMESPACE = "urn:OECD:StandardAuditFile-Tax:AO_1.01_01"
+
+
+def _write_invalid_xml(path: Path) -> None:
+    path.write_text(
+        f"""<?xml version='1.0' encoding='UTF-8'?>
+<AuditFile xmlns=\"{NAMESPACE}\" xmlns:ns=\"{NAMESPACE}\">
+  <Header>
+    <TaxRegistrationNumber>AO123456789</TaxRegistrationNumber>
+  </Header>
+  <MasterFiles>
+    <ns:Customer>
+      <ns:CustomerID>1000</ns:CustomerID>
+      <ns:CustomerTaxID>999999990</ns:CustomerTaxID>
+      <ns:CompanyName>Cliente Teste</ns:CompanyName>
+      <ns:SelfBillingIndicator>0</ns:SelfBillingIndicator>
+    </ns:Customer>
+  </MasterFiles>
+  <SourceDocuments>
+    <SalesInvoices>
+      <Invoice>
+        <InvoiceNo>FT 1/1</InvoiceNo>
+        <CustomerID>1000</CustomerID>
+        <Line>
+          <LineNumber>1</LineNumber>
+          <Tax>
+            <TaxType>IVA</TaxType>
+            <TaxCode>NOR</TaxCode>
+          </Tax>
+        </Line>
+      </Invoice>
+    </SalesInvoices>
+  </SourceDocuments>
+</AuditFile>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_validator_reports_expected_errors(tmp_path):
+    xml_path = tmp_path / "invalid.xml"
+    _write_invalid_xml(xml_path)
+
+    issues = list(validate_file(xml_path))
+
+    codes = {issue.code for issue in issues}
+    assert codes == {
+        "CUSTOMER_WRONG_NAMESPACE",
+        "INVOICE_CUSTOMER_MISSING",
+        "HEADER_TAX_ID_INVALID",
+        "TAX_COUNTRY_REGION_MISSING",
+    }
+
+    header_issue = next(i for i in issues if i.code == "HEADER_TAX_ID_INVALID")
+    assert header_issue.details["suggested_value"] == "123456789"
+
+    invoice_issue = next(i for i in issues if i.code == "INVOICE_CUSTOMER_MISSING")
+    assert invoice_issue.details["customer_id"] == "1000"


### PR DESCRIPTION
## Summary
- normalise MasterFiles customer namespaces and strip non-digit prefixes from TaxRegistrationNumber during auto-fixes
- add validation checks for prefixed customers, missing invoice customers, invalid TaxRegistrationNumber values, and absent TaxCountryRegion entries
- cover the new behaviour with regression tests for the validator and soft/hard auto-fix flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6622522e883229f40c3027a73507c