### PR TITLE
Fix validator script import when running from source

### DIFF
--- a/scripts/validator_saft_ao.py
+++ b/scripts/validator_saft_ao.py
@@ -6,6 +6,21 @@ as distribuições antigas continuem a funcionar enquanto o pacote ``saftao`` é
 utilizado como fonte de verdade.
 """
 
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# NOTE: Quando o pacote é utilizado diretamente a partir do repositório ainda
+# não instalado (``pip install .``), o Python não encontra automaticamente o
+# diretório ``src``. Para manter a compatibilidade com o comportamento legado do
+# script, adicionamos o caminho do ``src`` ao ``sys.path`` antes de importar o
+# comando principal.
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_SRC_PATH = _PROJECT_ROOT / "src"
+if str(_SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(_SRC_PATH))
+
 from saftao.commands.validator_strict import main
 
 if __name__ == "__main__":  # pragma: no cover - compatibilidade


### PR DESCRIPTION
## Summary
- ensure validator_saft_ao.py adds the repository src directory to sys.path before importing the saftao package

## Testing
- python scripts/validator_saft_ao.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e66de053bc832286e11948d9e7fd29