### PR TITLE
Integrate validator module into strict CLI

### DIFF
--- a/tests/test_validator_detection.py
+++ b/tests/test_validator_detection.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from lxml import etree
+
+from saftao.commands.validator_strict import validate_business_rules
 from saftao.validator import validate_file
 
 NAMESPACE = "urn:OECD:StandardAuditFile-Tax:AO_1.01_01"
@@ -62,3 +65,32 @@ def test_validator_reports_expected_errors(tmp_path):
 
     invoice_issue = next(i for i in issues if i.code == "INVOICE_CUSTOMER_MISSING")
     assert invoice_issue.details["customer_id"] == "1000"
+
+
+class _DummyLogger:
+    def __init__(self) -> None:
+        self.entries: list[dict[str, object]] = []
+
+    def log(self, code: str, message: str, **kwargs: object) -> None:
+        entry = {"code": code, "message": message}
+        entry.update(kwargs)
+        self.entries.append(entry)
+
+
+def test_validator_strict_includes_additional_issues(tmp_path):
+    xml_path = tmp_path / "invalid.xml"
+    _write_invalid_xml(xml_path)
+
+    tree = etree.parse(str(xml_path))
+    logger = _DummyLogger()
+
+    ok = validate_business_rules(tree, logger)
+
+    assert not ok
+    codes = {entry["code"] for entry in logger.entries}
+    assert {
+        "CUSTOMER_WRONG_NAMESPACE",
+        "INVOICE_CUSTOMER_MISSING",
+        "HEADER_TAX_ID_INVALID",
+        "TAX_COUNTRY_REGION_MISSING",
+    }.issubset(codes)


### PR DESCRIPTION
## Summary
- bridge issues detected by `saftao.validator` into the legacy strict CLI logger so namespace, tax ID, and tax country region problems fail validation
- cover the new integration with a regression test that ensures the strict validator reports those issue codes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e67863180c832286297c47ed950fe6