### PR TITLE
Add AGT log parser stubs

### DIFF
--- a/src/saftao/__init__.py
+++ b/src/saftao/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     "tax_table",
     "invoices",
     "schema",
+    "agt_logs",
 ]

--- a/src/saftao/agt_logs.py
+++ b/src/saftao/agt_logs.py
@@ -1,0 +1,50 @@
+"""Utilities for parsing AGT validation error logs.
+
+This module will eventually expose helpers capable of reading the
+spreadsheets produced pela AGT (em formato ``.xlsx``) e converter cada
+linha em estruturas de dados ricas consumidas pelo validador.  Enquanto a
+migração dos scripts legados não estiver concluída mantemos as funções
+como *stubs* para que a API pública esteja preparada.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(slots=True)
+class AgtLogEntry:
+    """Representa uma linha do relatório de erros devolvido pela AGT."""
+
+    code: str
+    message: str
+    source: str | None = None
+
+
+def parse_error_workbook(path: Path) -> Iterable[AgtLogEntry]:
+    """Ler o ficheiro Excel emitido pela AGT e produzir entradas estruturadas.
+
+    Parameters
+    ----------
+    path:
+        Caminho para o ficheiro ``.xlsx`` extraído do portal da AGT.
+
+    Returns
+    -------
+    Iterable[AgtLogEntry]
+        Sequência de entradas correspondentes a cada linha do relatório.
+
+    Notes
+    -----
+    A implementação será preenchida assim que a migração dos scripts
+    ``validator_saft_ao.py`` para o pacote `saftao` estiver concluída.
+    Até lá, a função actua como *stub* para permitir que o restante código
+    possa importar esta API sem falhas.
+    """
+
+    raise NotImplementedError("Workbook parsing ainda não foi implementado")
+
+
+__all__ = ["AgtLogEntry", "parse_error_workbook"]

--- a/tests/test_agt_log_parser_stub.py
+++ b/tests/test_agt_log_parser_stub.py
@@ -1,0 +1,26 @@
+"""Tests ensuring the AGT log parser stub is available for future work."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from saftao import agt_logs
+
+
+def test_parse_error_workbook_stub(tmp_path: Path) -> None:
+    dummy = tmp_path / "report.xlsx"
+    dummy.write_bytes(b"PK\x03\x04")  # minimal ZIP header for XLSX placeholder
+
+    with pytest.raises(NotImplementedError):
+        list(agt_logs.parse_error_workbook(dummy))
+
+
+def test_agt_log_entry_dataclass_repr() -> None:
+    entry = agt_logs.AgtLogEntry(code="ERR", message="Mensagem", source="linha 1")
+
+    repr_text = repr(entry)
+
+    assert "ERR" in repr_text
+    assert "Mensagem" in repr_text


### PR DESCRIPTION
## Summary
- add a placeholder `agt_logs` module exporting an `AgtLogEntry` dataclass and workbook parser stub
- expose the new module through the package namespace and cover it with a smoke test that asserts the stub is present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e682611d148322a31a6b39b5b27575